### PR TITLE
Add Github Actions OIDC provider

### DIFF
--- a/parties/githubclient.go
+++ b/parties/githubclient.go
@@ -30,7 +30,7 @@ type GithubOp struct {
 	tokenRequestAuthToken string
 }
 
-var _ OpenIdProvider = &GithubOp{}
+var _ OpenIdProvider = (*GithubOp)(nil)
 
 func NewGithubOpFromEnvironment() (*GithubOp, error) {
 	tokenURL, err := getEnvVar("ACTIONS_ID_TOKEN_REQUEST_URL")

--- a/parties/githubclient.go
+++ b/parties/githubclient.go
@@ -196,7 +196,10 @@ func (g *GithubOp) VerifyPKToken(pktJSON []byte, cosPk *ecdsa.PublicKey) (map[st
 		}
 
 		var payload map[string]any
-		json.Unmarshal(payloadJSON, &payload)
+		err = json.Unmarshal(payloadJSON, &payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal payload")
+		}
 		aud := payload["aud"]
 		if aud != expectedAud {
 			return nil, fmt.Errorf("aud doesn't match, got %q, expected %q", aud, expectedAud)

--- a/parties/githubclient.go
+++ b/parties/githubclient.go
@@ -99,12 +99,9 @@ func (g *GithubOp) PublicKey(idt []byte) (PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("key %q isn't in JWKS", kid)
 	}
-	keyAlg, keyType := key.Algorithm(), key.KeyType()
+	keyAlg := key.Algorithm()
 	if keyAlg != jwa.RS256 {
 		return nil, fmt.Errorf("expected RS256 key, got %s", keyAlg)
-	}
-	if keyType != jwa.RSA {
-		return nil, fmt.Errorf("expected RSA key type, got %s", keyType)
 	}
 
 	pubKey := new(rsa.PublicKey)

--- a/parties/githubclient.go
+++ b/parties/githubclient.go
@@ -1,18 +1,229 @@
 package parties
 
 import (
+	"bytes"
+	"context"
 	"crypto/ecdsa"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/bastionzero/openpubkey/gq"
+	"github.com/bastionzero/openpubkey/pktoken"
+	"github.com/bastionzero/openpubkey/util"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/zitadel/oidc/v2/pkg/client"
 )
 
+const githubIssuer = "https://token.actions.githubusercontent.com"
+
 type GithubOp struct {
+	rawTokenRequestURL    string
+	tokenRequestAuthToken string
 }
 
-func (h *GithubOp) RequestTokens(cicHash string) ([]byte, error) {
-	// TODO: Add github action call here
-	return nil, nil
+var _ OpenIdProvider = &GithubOp{}
+
+func NewGithubOpFromEnvironment() (*GithubOp, error) {
+	tokenURL, err := getEnvVar("ACTIONS_ID_TOKEN_REQUEST_URL")
+	if err != nil {
+		return nil, err
+	}
+	token, err := getEnvVar("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	if err != nil {
+		return nil, err
+	}
+
+	return NewGithubOp(tokenURL, token), nil
 }
 
-func (h *GithubOp) VerifyPKToken(pktCom []byte, cosPk *ecdsa.PublicKey) error {
-	// TODO: Add github action call here
-	return nil
+func getEnvVar(name string) (string, error) {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return "", fmt.Errorf("%q environment variable not set", name)
+	}
+	return value, nil
+}
+
+func NewGithubOp(tokenURL string, token string) *GithubOp {
+	return &GithubOp{
+		rawTokenRequestURL:    tokenURL,
+		tokenRequestAuthToken: token,
+	}
+}
+
+func buildTokenURL(rawTokenURL, audience string) (string, error) {
+	parsedURL, err := url.Parse(rawTokenURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	if audience == "" {
+		return "", fmt.Errorf("audience is required")
+	}
+
+	query := parsedURL.Query()
+	query.Set("audience", audience)
+	parsedURL.RawQuery = query.Encode()
+	return parsedURL.String(), nil
+}
+
+func (g *GithubOp) PublicKey(idt []byte) (PublicKey, error) {
+	j, err := jws.Parse(idt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JWS: %w", err)
+	}
+	kid := j.Signatures()[0].ProtectedHeaders().KeyID()
+
+	discConf, err := client.Discover(githubIssuer, http.DefaultClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call OIDC discovery endpoint: %w", err)
+	}
+
+	jwks, err := jwk.Fetch(context.TODO(), discConf.JwksURI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch to JWKS: %w", err)
+	}
+
+	key, ok := jwks.LookupKeyID(kid)
+	if !ok {
+		return nil, fmt.Errorf("key isn't in JWKS")
+	}
+
+	pubKey := new(rsa.PublicKey)
+	err = key.Raw(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode public key: %w", err)
+	}
+
+	return pubKey, err
+}
+
+func (g *GithubOp) RequestTokens(cicHash string) ([]byte, error) {
+	tokenURL, err := buildTokenURL(g.rawTokenRequestURL, cicHash)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest("GET", tokenURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("Authorization", "Bearer "+g.tokenRequestAuthToken)
+
+	var httpClient http.Client
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received non-200 from jwt api: %s", http.StatusText(response.StatusCode))
+	}
+
+	rawBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var jwt struct {
+		Value string
+	}
+	err = json.Unmarshal(rawBody, &jwt)
+
+	return []byte(jwt.Value), err
+}
+
+func (g *GithubOp) VerifyPKToken(pktJSON []byte, cosPk *ecdsa.PublicKey) (map[string]any, error) {
+	pkt, err := pktoken.FromJSON(pktJSON)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing PK Token: %w", err)
+	}
+
+	cicphJSON, err := util.Base64DecodeForJWT(pkt.CicPH)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := string(util.B64SHA3_256(cicphJSON))
+
+	idt := pkt.OpJWSCompact()
+
+	// TODO: this needs to get the public key from a log of historic public keys based on the iat time in the token
+	pubKey, err := g.PublicKey(idt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OP public key: %w", err)
+	}
+
+	rsaPubKey := pubKey.(*rsa.PublicKey)
+
+	if pkt.OpSigGQ {
+		sv := gq.NewSignerVerifier(rsaPubKey, gqSecurityParameter)
+		signingPayload, signature, err := util.SplitJWT(idt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to split/decode JWT: %w", err)
+		}
+		ok := sv.Verify(signature, signingPayload, signingPayload)
+		if !ok {
+			return nil, fmt.Errorf("error verifying OP GQ signature on PK Token (ID Token invalid)")
+		}
+
+		payloadB64 := bytes.Split(signingPayload, []byte{'.'})[1]
+		payloadJSON, err := util.Base64DecodeForJWT(payloadB64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode header")
+		}
+
+		var payload map[string]any
+		json.Unmarshal(payloadJSON, &payload)
+		if payload["aud"] != nonce {
+			return nil, fmt.Errorf("nonce doesn't match, got %q, expected %q", payload["aud"], nonce)
+		}
+
+	} else {
+		// TODO: check this is correct
+		// I wonder if we actually want to support this branch (non-GQ) at all?
+		_, err = jwt.Parse(idt, jwt.WithAudience(nonce), jwt.WithIssuer(githubIssuer), jwt.WithAcceptableSkew(5*time.Second), jwt.WithKey(jwa.RS256, rsaPubKey))
+		if err != nil {
+			return nil, fmt.Errorf("failed to verify token: %w", err)
+		}
+	}
+
+	err = pkt.VerifyCicSig()
+	if err != nil {
+		return nil, fmt.Errorf("error verifying CIC signature on PK Token: %w", err)
+	}
+
+	// Skip Cosigner signature verification if no cosigner pubkey is supplied
+	if cosPk != nil {
+		cosPkJwk, err := jwk.FromRaw(cosPk)
+		if err != nil {
+			return nil, fmt.Errorf("error verifying CIC signature on PK Token: %w", err)
+		}
+
+		err = pkt.VerifyCosSig(cosPkJwk, jwa.KeyAlgorithmFrom("ES256"))
+		if err != nil {
+			return nil, fmt.Errorf("error verify cosigner signature on PK Token: %w", err)
+		}
+	}
+
+	fmt.Println("All tests have passed PK Token is valid")
+
+	cicPH := make(map[string]any)
+	err = json.Unmarshal(cicphJSON, &cicPH)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling CIC: %w", err)
+	}
+
+	return cicPH, nil
 }

--- a/parties/googleclient.go
+++ b/parties/googleclient.go
@@ -44,6 +44,8 @@ type GoogleOp struct {
 	server       *http.Server
 }
 
+var _ OpenIdProvider = &GoogleOp{}
+
 func (g *GoogleOp) RequestTokens(cicHash string) ([]byte, error) {
 	cookieHandler :=
 		httphelper.NewCookieHandler(key, key, httphelper.WithUnsecure())

--- a/parties/googleclient.go
+++ b/parties/googleclient.go
@@ -44,7 +44,7 @@ type GoogleOp struct {
 	server       *http.Server
 }
 
-var _ OpenIdProvider = &GoogleOp{}
+var _ OpenIdProvider = (*GoogleOp)(nil)
 
 func (g *GoogleOp) RequestTokens(cicHash string) ([]byte, error) {
 	cookieHandler :=

--- a/parties/opkclient.go
+++ b/parties/opkclient.go
@@ -70,11 +70,7 @@ func (o *OpkClient) OidcAuth() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error verifying PK Token: %w", err)
 	}
-	err = o.Signer.WriteToFile(pktJSON)
-	if err != nil {
-		return nil, fmt.Errorf("error writing PK Token: %w", err)
-	}
-	return idt, nil
+	return pktJSON, nil
 }
 
 type TokenCallback func(tokens *oidc.Tokens[*oidc.IDTokenClaims])

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -10,8 +10,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
-
-	"github.com/bastionzero/openpubkey/util"
 )
 
 const SigTypeHeader = "sig_type"
@@ -336,19 +334,6 @@ func (p *PKToken) GetCosValues() (*CosPHeader, error) {
 // }
 
 func (p *PKToken) VerifyCicSig() error {
-	nonce, err := p.GetNonce()
-	if err != nil {
-		return err
-	}
-	decodedCicPH, err := base64.RawStdEncoding.DecodeString(string(p.CicPH))
-	if err != nil {
-		return err
-	}
-	cicHash := util.B64SHA3_256(decodedCicPH)
-
-	if !bytes.Equal(nonce, cicHash) {
-		return fmt.Errorf("Nonce in the ID Token payload (%s) does not commit to the CIC values in the signature header (%s).", nonce, cicHash)
-	}
 	cicJwsCom := p.CicJWSCompact()
 
 	alg, _, upk, err := p.GetCicValues()

--- a/pktoken/signer.go
+++ b/pktoken/signer.go
@@ -66,10 +66,15 @@ func LoadSigner(cfgPath string, pktCom []byte, uSk *ecdsa.PrivateKey, alg string
 	if err != nil {
 		return nil, err
 	}
+	rz, err := GenRZ()
+	if err != nil {
+		return nil, err
+	}
 
 	return &Signer{
 		Pksk:     uSk,
 		alg:      alg,
+		rz:       rz,
 		PktCom:   pktCom,
 		GqSig:    gqSig,
 		cfgPath:  cfgPath,


### PR DESCRIPTION
Closes #5 

- Add Github Actions OIDC provider
- Don't write PK token to disk
- Add rz when loading signer
- Don't verify nonce in `VerifyCicSig`

This has introduced quite a lot of duplication between this and the Google provider, I don't think the `OpenIdProvider` interface is quite right. I'll add a ticket for addressing that.
