### PR TITLE
Add linter to PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,43 @@
+name: Go Checks
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+
+jobs:
+    gofmt:
+        name: Check Code Format
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+            
+            - name: Set up Go
+              uses: actions/setup-go@v2
+              with:
+                  go-version: 1.20
+            
+            - name: Check formatting
+              run: |
+                FILES=$(gofmt -l .)
+                if [ -n "$FILES" ]; then
+                echo "These files are not formatted correctly:"
+                echo "$FILES"
+                exit 1
+                fi
+
+    govet:
+        name: Vet Code
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+
+        - name: Set up Go
+          uses: actions/setup-go@v2
+          with:
+            go-version: 1.20
+
+        - name: Vet
+          run: go vet ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,38 +6,38 @@ on:
       - '**.go'
 
 jobs:
-    gofmt:
-        name: Check Code Format
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-            
-            - name: Set up Go
-              uses: actions/setup-go@v2
-              with:
-                  go-version: 1.20
-            
-            - name: Check formatting
-              run: |
-                FILES=$(gofmt -l .)
-                if [ -n "$FILES" ]; then
-                echo "These files are not formatted correctly:"
-                echo "$FILES"
-                exit 1
-                fi
+  gofmt:
+    name: Check Code Format
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.20.8
+    
+    - name: Check formatting
+      run: |
+        FILES=$(gofmt -l .)
+        if [ -n "$FILES" ]; then
+          echo "These files are not formatted correctly:"
+          echo "$FILES"
+          exit 1
+        fi
 
-    govet:
-        name: Vet Code
-        runs-on: ubuntu-latest
-        steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
+  govet:
+    name: Vet Code
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
 
-        - name: Set up Go
-          uses: actions/setup-go@v2
-          with:
-            go-version: 1.20
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.20.8
 
-        - name: Vet
-          run: go vet ./...
+    - name: Vet
+      run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Phase 1:
 - [ ] [Cryptography review and remediation](https://github.com/openpubkey/openpubkey/issues/11)
 - [ ] Opensource project must haves
   - [ ] Github actions to run unittest
-  - [ ] Linter enforcement
+  - [x] Linter enforcement
   - [ ] Code of conduct
   - [ ] Security.md
   - [ ] Developer.md

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -78,12 +78,18 @@ func PktTox509(pktCom []byte, caBytes []byte, caPkSk *ecdsa.PrivateKey, required
 	// }
 
 	iss, aud, email, err := pkt.GetClaims()
+	if err != nil {
+		return nil, err
+	}
 
 	if string(aud) != requiredAudience {
-		return nil, fmt.Errorf("Audience 'aud' claim in PK Tokem did not match audience required by CA, it was %s instead.", string(aud))
+		return nil, fmt.Errorf("audience 'aud' claim in PK Tokem did not match audience required by CA, it was %s instead", string(aud))
 	}
 
 	caTemplate, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		return nil, err
+	}
 
 	subject := string(email)
 	oidcIssuer := iss

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -83,7 +83,7 @@ func PktTox509(pktCom []byte, caBytes []byte, caPkSk *ecdsa.PrivateKey, required
 	}
 
 	if string(aud) != requiredAudience {
-		return nil, fmt.Errorf("audience 'aud' claim in PK Tokem did not match audience required by CA, it was %s instead", string(aud))
+		return nil, fmt.Errorf("audience 'aud' claim in PK Token did not match audience required by CA, it was %s instead", string(aud))
 	}
 
 	caTemplate, err := x509.ParseCertificate(caBytes)

--- a/cert/ca_test.go
+++ b/cert/ca_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -31,8 +30,6 @@ func TestCertCreation(t *testing.T) {
 		t.Error(err)
 	}
 
-	fmt.Printf("SubCert.Raw %s\n", string(pemSubCert))
-
 	decodeBlock, _ := pem.Decode(pemSubCert)
 
 	cc, err := x509.ParseCertificate(decodeBlock.Bytes)
@@ -40,7 +37,6 @@ func TestCertCreation(t *testing.T) {
 		t.Error(err)
 	}
 
-	fmt.Printf("SubID %s\n", cc.SubjectKeyId)
 	certPubkey := cc.PublicKey.(*ecdsa.PublicKey)
 
 	pkt, err := pktoken.FromCompact(pktCom)

--- a/parties/ca.go
+++ b/parties/ca.go
@@ -195,7 +195,7 @@ func (a *Ca) PktTox509(pktCom []byte, caBytes []byte) ([]byte, error) {
 	}
 
 	if string(aud) != requiredAudience {
-		return nil, fmt.Errorf("audience 'aud' claim in PK Tokem did not match audience required by CA, it was %s instead", string(aud))
+		return nil, fmt.Errorf("audience 'aud' claim in PK Token did not match audience required by CA, it was %s instead", string(aud))
 	}
 
 	caTemplate, err := x509.ParseCertificate(caBytes)

--- a/parties/ca.go
+++ b/parties/ca.go
@@ -133,14 +133,13 @@ func (a *Ca) Serv() {
 	issueCertAuthHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		params := r.URL.Query()
-		fmt.Printf("params: %s\n", params)
 		pktCom := []byte(params["pkt"][0])
-
-		fmt.Printf("Everything checks out: %v\n", pktCom)
 
 		pktX509, err := a.PktTox509(pktCom, a.CaCertBytes)
 		if err != nil {
-			fmt.Printf("Error creating x509 for PK Token: %v\n", err)
+			rerr := fmt.Errorf("error creating x509 for PK Token: %v", err)
+			w.Header().Set("Error", rerr.Error())
+			http.Error(w, rerr.Error(), http.StatusInternalServerError)
 			return
 		}
 
@@ -156,8 +155,6 @@ func (a *Ca) Serv() {
 		// m.authCodeMap[authcode] = string(cosPktCom)
 
 		// fmt.Printf("Got authcode map value: |%s|\n", m.authCodeMap[authcode])
-
-		fmt.Printf("Issuing cert: %v\n", string(pktX509))
 
 		w.Write(pktX509)
 	})
@@ -193,12 +190,18 @@ func (a *Ca) PktTox509(pktCom []byte, caBytes []byte) ([]byte, error) {
 	// }
 
 	iss, aud, email, err := pkt.GetClaims()
+	if err != nil {
+		return nil, err
+	}
 
 	if string(aud) != requiredAudience {
-		return nil, fmt.Errorf("Audience 'aud' claim in PK Tokem did not match audience required by CA, it was %s instead.", string(aud))
+		return nil, fmt.Errorf("audience 'aud' claim in PK Tokem did not match audience required by CA, it was %s instead", string(aud))
 	}
 
 	caTemplate, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		return nil, err
+	}
 
 	subject := string(email)
 	oidcIssuer := iss

--- a/parties/googleclient.go
+++ b/parties/googleclient.go
@@ -61,7 +61,7 @@ func (g *GoogleOp) RequestTokens(cicHash string) ([]byte, error) {
 		g.Issuer, g.ClientID, g.ClientSecret, g.RedirectURI,
 		g.Scopes, options...)
 	if err != nil {
-		return nil, fmt.Errorf("error creating provider %w", err)
+		return nil, fmt.Errorf("error creating provider: %w", err)
 	}
 
 	state := func() string {

--- a/util/files.go
+++ b/util/files.go
@@ -31,8 +31,6 @@ func WritePKFile(fpath string, pk *ecdsa.PublicKey) error {
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509Encoded})
 
-	fmt.Printf("ERH: X. writing fpath  : %v \n", x509Encoded)
-
 	err = os.WriteFile(fpath, pemBytes, 0600)
 	if err != nil {
 		return err
@@ -149,7 +147,6 @@ func GetRandString(n int) (string, error) {
 	b := make([]byte, n)
 	_, err := rand.Read(b)
 	if err != nil {
-		fmt.Println("error:", err)
 		return "", err
 	}
 	return hex.EncodeToString(b), err


### PR DESCRIPTION
Add linter in the form of `gofmt` and `govet` enforcement. Only runs on PRs with changes to any go files.

Fixes any of those issues in the existing code.