### PR TITLE
Remove cosigner code from everywhere except pktoken

### DIFF
--- a/cert/ca.go
+++ b/cert/ca.go
@@ -13,16 +13,8 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
-
 	"github.com/openpubkey/openpubkey/pktoken"
 )
-
-type CosignerConfig struct {
-	Alg    jwa.KeyAlgorithm
-	Pubkey jwk.Key
-}
 
 func GenCAKeyPair() ([]byte, *ecdsa.PrivateKey, error) {
 	caTemplate := &x509.Certificate{
@@ -66,16 +58,6 @@ func PktTox509(pktCom []byte, caBytes []byte, caPkSk *ecdsa.PrivateKey, required
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: verify cosigner
-	// cosignerConfig := &CosignerConfig {
-	// 	Alg: "ES256",
-	// 	Pubkey: "TODO",
-	// }
-	// err = pkt.VerifyCosSig()
-	// if err != nil {
-	// 	return nil, err
-	// }
 
 	iss, aud, email, err := pkt.GetClaims()
 	if err != nil {

--- a/examples/google/config.go
+++ b/examples/google/config.go
@@ -15,6 +15,5 @@ var (
 	redirectURI  = fmt.Sprintf("http://localhost:%v%v", redirURIPort, callbackPath)
 
 	fpClientCfg = "configs/clcfg"
-	fpMfaCfg    = "configs/mfacfg"
 	fpCaCfg     = "configs/cacfg"
 )

--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -163,7 +163,6 @@ func SigStoreSign() {}
 func main() {
 
 	fpClientCfg = "configs/clcfg"
-	fpMfaCfg = "configs/mfacfg"
 	fpCaCfg = "configs/cacfg"
 
 	if len(os.Args) < 2 {

--- a/parties/ca.go
+++ b/parties/ca.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openpubkey/openpubkey/pktoken"
@@ -28,11 +27,6 @@ import (
 var (
 	requiredAudience = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
 )
-
-type CosignerConfig struct {
-	Alg    jwa.KeyAlgorithm
-	Pubkey jwk.Key
-}
 
 type Ca struct {
 	pksk        *ecdsa.PrivateKey
@@ -143,19 +137,6 @@ func (a *Ca) Serv() {
 			return
 		}
 
-		// kid := m.cosigner.GetPublicKey().X509CertThumbprint()
-		// cosPktCom, err := m.cosigner.SignPKToken(pktCom, ruri, kid)
-		// if err != nil {
-		// 	fmt.Printf("Error getting PK Token cosigned: %s", err.Error())
-		// 	return
-		// }
-		// fmt.Printf("Successfully created a cosigned PK Token: %v\n", string(cosPktCom))
-
-		// authcode := "1234567890" // TODO: Make random
-		// m.authCodeMap[authcode] = string(cosPktCom)
-
-		// fmt.Printf("Got authcode map value: |%s|\n", m.authCodeMap[authcode])
-
 		w.Write(pktX509)
 	})
 
@@ -178,16 +159,6 @@ func (a *Ca) PktTox509(pktCom []byte, caBytes []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: verify cocigner
-	// cosignerConfig := &CosignerConfig {
-	// 	Alg: "ES256",
-	// 	Pubkey: "TODO",
-	// }
-	// err = pkt.VerifyCosSig()
-	// if err != nil {
-	// 	return nil, err
-	// }
 
 	iss, aud, email, err := pkt.GetClaims()
 	if err != nil {

--- a/parties/githubclient.go
+++ b/parties/githubclient.go
@@ -3,7 +3,6 @@ package parties
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
@@ -150,7 +149,7 @@ func (g *GithubOp) RequestTokens(cicHash string) ([]byte, error) {
 	return []byte(jwt.Value), err
 }
 
-func (g *GithubOp) VerifyPKToken(pktJSON []byte, cosPk *ecdsa.PublicKey) (map[string]any, error) {
+func (g *GithubOp) VerifyPKToken(pktJSON []byte) (map[string]any, error) {
 	pkt, err := pktoken.FromJSON(pktJSON)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing PK Token: %w", err)
@@ -206,19 +205,6 @@ func (g *GithubOp) VerifyPKToken(pktJSON []byte, cosPk *ecdsa.PublicKey) (map[st
 	err = pkt.VerifyCicSig()
 	if err != nil {
 		return nil, fmt.Errorf("error verifying CIC signature on PK Token: %w", err)
-	}
-
-	// Skip Cosigner signature verification if no cosigner pubkey is supplied
-	if cosPk != nil {
-		cosPkJwk, err := jwk.FromRaw(cosPk)
-		if err != nil {
-			return nil, fmt.Errorf("error verifying CIC signature on PK Token: %w", err)
-		}
-
-		err = pkt.VerifyCosSig(cosPkJwk, jwa.KeyAlgorithmFrom("ES256"))
-		if err != nil {
-			return nil, fmt.Errorf("error verify cosigner signature on PK Token: %w", err)
-		}
 	}
 
 	cicPH := make(map[string]any)

--- a/parties/googleclient.go
+++ b/parties/googleclient.go
@@ -3,7 +3,6 @@ package parties
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/sirupsen/logrus"
@@ -113,7 +111,7 @@ func (g *GoogleOp) RequestTokens(cicHash string) ([]byte, error) {
 	}
 }
 
-func (g *GoogleOp) VerifyPKToken(pktJSON []byte, cosPk *ecdsa.PublicKey) (map[string]any, error) {
+func (g *GoogleOp) VerifyPKToken(pktJSON []byte) (map[string]any, error) {
 	pkt, err := pktoken.FromJSON(pktJSON)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing PK Token: %w", err)
@@ -177,19 +175,6 @@ func (g *GoogleOp) VerifyPKToken(pktJSON []byte, cosPk *ecdsa.PublicKey) (map[st
 	err = pkt.VerifyCicSig()
 	if err != nil {
 		return nil, fmt.Errorf("error verifying CIC signature on PK Token: %w", err)
-	}
-
-	// Skip Cosigner signature verification if no cosigner pubkey is supplied
-	if cosPk != nil {
-		cosPkJwk, err := jwk.FromRaw(cosPk)
-		if err != nil {
-			return nil, fmt.Errorf("error verifying CIC signature on PK Token: %w", err)
-		}
-
-		err = pkt.VerifyCosSig(cosPkJwk, jwa.KeyAlgorithmFrom("ES256"))
-		if err != nil {
-			return nil, fmt.Errorf("error verify cosigner signature on PK Token: %w", err)
-		}
 	}
 
 	cicPH := make(map[string]any)

--- a/pktoken/signer.go
+++ b/pktoken/signer.go
@@ -179,8 +179,6 @@ func (s *Signer) CreatePkToken(idtCom []byte) (*PKToken, error) {
 		OpSig:   opSig,
 		CicPH:   cicPH,
 		CicSig:  cicSig,
-		CosSig:  nil,
-		CosPH:   nil,
 	}, nil
 }
 


### PR DESCRIPTION
I don't believe we should have unused, unsupported, partially implemented code in the repo. Even if it's going to be re-added in 2 weeks, we shouldn't keep it around so that we can best accommodate any changes to the repo when we do so. It is also a bit distracting and confusing and considering this is technically a public, opensource repo, we should strive to minimize those two adjectives.

I removed most of the cosigning code except for structurally within the pk token where I think we should have a discussion first.