### PR TITLE
Bug fix when assigning gq signature to pktoken

### DIFF
--- a/parties/googleclient.go
+++ b/parties/googleclient.go
@@ -135,7 +135,7 @@ func (g *GoogleOp) VerifyPKToken(pktJSON []byte, cosPk *ecdsa.PublicKey) (map[st
 		sv := gq.NewSignerVerifier(pubKey.(*rsa.PublicKey), gqSecurityParameter)
 		ok := sv.VerifyJWT(idt)
 		if !ok {
-			return nil, fmt.Errorf("error verifying OP GQ signature on PK Token (ID Token invalid): %w", err)
+			return nil, fmt.Errorf("error verifying OP GQ signature on PK Token (ID Token invalid)")
 		}
 
 		_, payloadB64, _, err := jws.SplitCompact(idt)

--- a/parties/opkclient.go
+++ b/parties/opkclient.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
 
 	"github.com/openpubkey/openpubkey/gq"
@@ -49,9 +50,13 @@ func (o *OpkClient) OidcAuth() ([]byte, error) {
 		rsaPubKey := opKey.(*rsa.PublicKey)
 
 		sv := gq.NewSignerVerifier(rsaPubKey, gqSecurityParameter)
-		gqSig, err := sv.SignJWT(idt)
+		gqToken, err := sv.SignJWT(idt)
 		if err != nil {
 			return nil, fmt.Errorf("error creating GQ signature: %w", err)
+		}
+		_, _, gqSig, err := jws.SplitCompact(gqToken)
+		if err != nil {
+			return nil, err
 		}
 
 		pkt.OpSig = gqSig


### PR DESCRIPTION
I introduced this bug in #28. `VerifyJWT()` differed from the existing code in that it returned an entire token instead of just the signature. Fixed that plus a small issue that we were printing an error when VerifyJWT returns a bool so error was always nil.