### PR TITLE
feat: gq test modified payloads

### DIFF
--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -57,6 +57,10 @@ func TestVerifyModifiedIdPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = jws.Verify(modifiedToken, jws.WithKey(jwa.RS256, oidcPubKey))
+	if err == nil {
+		t.Fatal("ID token signature should fail for modified token")
+	}
 
 	signerVerifier := gq.NewSignerVerifier(oidcPubKey, 256)
 	gqToken, err := signerVerifier.SignJWT(modifiedToken)
@@ -66,7 +70,7 @@ func TestVerifyModifiedIdPayload(t *testing.T) {
 
 	ok := signerVerifier.VerifyJWT(gqToken)
 	if ok {
-		t.Fatal("signature verification passed for invalid payload")
+		t.Fatal("GQ signature verification passed for invalid payload")
 	}
 }
 
@@ -97,7 +101,7 @@ func TestVerifyModifiedGqPayload(t *testing.T) {
 
 	ok := signerVerifier.VerifyJWT(modifiedToken)
 	if ok {
-		t.Fatal("signature verification passed for invalid payload")
+		t.Fatal("GQ signature verification passed for invalid payload")
 	}
 }
 


### PR DESCRIPTION
* Adds tests to GQ for signature verification failure when the ID Token payload is modified
* `TestVerifyModifiedIdPayload`
  * modifies the ID Token payload before IdP signature is replaced by GQ signature
* `TestVerifyModifiedGqPayload`
  * modifies the ID Token payload after the GQ signature is generated

These tests ensure that a modified payload fails GQ signature verification in addition to the existing test of a valid payload passing GQ signature verification.