### PR TITLE
Allow setting op signature type on pk token creation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -74,7 +74,7 @@ func (o *OpkClient) OidcAuth(
 	}
 
 	// Combine our ID token and signature over the cic to create our PK Token
-	pkt, err := pktoken.New(idToken.Bytes(), cicToken)
+	pkt, err := pktoken.New(idToken.Bytes(), cicToken, signGQ)
 	if err != nil {
 		return nil, fmt.Errorf("error creating PK Token: %w", err)
 	}

--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/client/providers"
 	"github.com/openpubkey/openpubkey/gq"
+	"github.com/openpubkey/openpubkey/pktoken"
 	"github.com/openpubkey/openpubkey/util"
 )
 
@@ -44,7 +45,12 @@ func TestClient(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if tc.gq {
+		sigType, ok := pkt.ProviderSignatureType()
+		if !ok {
+			t.Fatal(fmt.Errorf("missing provider type"))
+		}
+
+		if sigType == pktoken.Gq {
 			// Verify our GQ signature
 			idt, err := pkt.Compact(pkt.Op)
 			if err != nil {

--- a/client/providers/google.go
+++ b/client/providers/google.go
@@ -164,6 +164,8 @@ func (g *GoogleOp) VerifyNonGQSig(ctx context.Context, idt []byte, expectedNonce
 		return fmt.Errorf("failed to create RP to verify token: %w", err)
 	}
 
+	fmt.Println(string(idt))
+
 	_, err = rp.VerifyIDToken[*oidc.IDTokenClaims](ctx, string(idt), googleRP.IDTokenVerifier())
 	if err != nil {
 		return fmt.Errorf("error verifying OP signature on PK Token (ID Token invalid): %w", err)

--- a/client/providers/google.go
+++ b/client/providers/google.go
@@ -164,8 +164,6 @@ func (g *GoogleOp) VerifyNonGQSig(ctx context.Context, idt []byte, expectedNonce
 		return fmt.Errorf("failed to create RP to verify token: %w", err)
 	}
 
-	fmt.Println(string(idt))
-
 	_, err = rp.VerifyIDToken[*oidc.IDTokenClaims](ctx, string(idt), googleRP.IDTokenVerifier())
 	if err != nil {
 		return fmt.Errorf("error verifying OP signature on PK Token (ID Token invalid): %w", err)

--- a/pktoken/mocks/pktoken.go
+++ b/pktoken/mocks/pktoken.go
@@ -56,5 +56,5 @@ func GenerateMockPKTokenWithEmail(signingKey crypto.Signer, alg jwa.KeyAlgorithm
 	}
 
 	// Combine two tokens into a PK Token
-	return pktoken.New(idToken.Bytes(), cicToken)
+	return pktoken.New(idToken.Bytes(), cicToken, false)
 }

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -36,9 +36,15 @@ type PKToken struct {
 	Cos     *Signature // Cosigner Signature
 }
 
-func New(idToken []byte, cicToken []byte) (*PKToken, error) {
+func New(idToken []byte, cicToken []byte, isGQ bool) (*PKToken, error) {
 	pkt := &PKToken{}
-	if err := pkt.AddSignature(idToken, Oidc); err != nil {
+
+	sigType := Oidc
+	if isGQ {
+		sigType = Gq
+	}
+
+	if err := pkt.AddSignature(idToken, sigType); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Before, we were assuming that the PK token was always being created with the oidp's ID token. That assumption changed in #48, but the code was still setting the signature type as `oidc` instead of `oidc_gq`. Therefore, the validator thought the provider's signature was non-gq and went through that flow where it failed because the signature was gq.

Relates to issue https://github.com/openpubkey/openpubkey/issues/62