### PR TITLE
Use GQ256 alg for GQ signatures

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -62,10 +62,16 @@ func (o *OpkClient) OidcAuth(
 		return nil, fmt.Errorf("error creating cic token: %w", err)
 	}
 
-	headers, _, _, err := jws.SplitCompact(idToken.Bytes())
+	headersB64, _, _, err := jws.SplitCompact(idToken.Bytes())
 	if err != nil {
 		return nil, fmt.Errorf("error getting original headers: %w", err)
 	}
+
+	headers, err := parseJWTSegment(headersB64)
+	if err != nil {
+		return nil, err
+	}
+
 	opKey, err := o.Op.PublicKey(ctx, headers)
 	if err != nil {
 		return nil, fmt.Errorf("error getting OP public key: %w", err)

--- a/client/client.go
+++ b/client/client.go
@@ -86,7 +86,7 @@ func (o *OpkClient) OidcAuth(
 	}
 
 	// Combine our ID token and signature over the cic to create our PK Token
-	pkt, err := pktoken.New(idToken.Bytes(), cicToken, signGQ)
+	pkt, err := pktoken.New(idToken.Bytes(), cicToken)
 	if err != nil {
 		return nil, fmt.Errorf("error creating PK Token: %w", err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/awnumar/memguard"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
 
 	"github.com/openpubkey/openpubkey/gq"
 	"github.com/openpubkey/openpubkey/pktoken"
@@ -61,13 +62,16 @@ func (o *OpkClient) OidcAuth(
 		return nil, fmt.Errorf("error creating cic token: %w", err)
 	}
 
-	opKey, err := o.Op.PublicKey(ctx, idToken.Bytes())
+	headers, _, _, err := jws.SplitCompact(idToken.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("error getting original headers: %w", err)
+	}
+	opKey, err := o.Op.PublicKey(ctx, headers)
 	if err != nil {
 		return nil, fmt.Errorf("error getting OP public key: %w", err)
 	}
 
 	if signGQ {
-
 		rsaPubKey := opKey.(*rsa.PublicKey)
 
 		sv, err := gq.NewSignerVerifier(rsaPubKey, GQSecurityParameter)

--- a/client/client.go
+++ b/client/client.go
@@ -67,7 +67,8 @@ func (o *OpkClient) OidcAuth(
 		return nil, fmt.Errorf("error getting original headers: %w", err)
 	}
 
-	headers, err := parseJWTSegment(headersB64)
+	headers := jws.NewHeaders()
+	err = parseJWTSegment(headersB64, &headers)
 	if err != nil {
 		return nil, err
 	}

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/awnumar/memguard"
 	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/openpubkey/openpubkey/gq"
 	"github.com/openpubkey/openpubkey/pktoken"
 	"github.com/openpubkey/openpubkey/util"
 )
@@ -93,8 +94,15 @@ func VerifyPKToken(ctx context.Context, pkt *pktoken.PKToken, provider OpenIdPro
 
 	switch sigType {
 	case pktoken.Gq:
+		origHeaders, err := gq.OriginalJWTHeaders(idt)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(origHeaders))
+
 		// TODO: this needs to get the public key from a log of historic public keys based on the iat time in the token
-		pubKey, err := provider.PublicKey(ctx, idt)
+		pubKey, err := provider.PublicKey(ctx, origHeaders)
 		if err != nil {
 			return fmt.Errorf("failed to get OP public key: %w", err)
 		}

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -89,7 +89,16 @@ func VerifyPKToken(ctx context.Context, pkt *pktoken.PKToken, provider OpenIdPro
 
 	idt, err := pkt.Compact(pkt.Op)
 	if err != nil {
-		return fmt.Errorf("")
+		return err
+	}
+
+	issuer, err := ExtractClaim(idt, "iss")
+	if err != nil {
+		return err
+	}
+
+	if issuer != provider.Issuer() {
+		return fmt.Errorf("expected token to have issuer %s, got %s", provider.Issuer(), issuer)
 	}
 
 	alg, ok := pkt.ProviderAlgorithm()

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -108,6 +108,20 @@ func VerifyPKToken(ctx context.Context, pkt *pktoken.PKToken, provider OpenIdPro
 			return err
 		}
 
+		algClaim, ok := origHeaderClaims["alg"]
+		if !ok {
+			return fmt.Errorf("missing alg claim")
+		}
+
+		alg, ok := algClaim.(string)
+		if !ok {
+			return fmt.Errorf("expected alg claim to contain a SignatureAlgorithm, got %T", algClaim)
+		}
+
+		if jwa.SignatureAlgorithm(alg) != jwa.RS256 {
+			return fmt.Errorf("expected original headers to contain RS256 alg, got %s", alg)
+		}
+
 		// TODO: this needs to get the public key from a log of historic public keys based on the iat time in the token
 		pubKey, err := provider.PublicKey(ctx, origHeaderClaims)
 		if err != nil {

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -69,6 +69,7 @@ func (id *OidcClaims) UnmarshalJSON(data []byte) error {
 
 // Interface for interacting with the OP (OpenID Provider)
 type OpenIdProvider interface {
+	Issuer() string
 	RequestTokens(ctx context.Context, cicHash string) (*memguard.LockedBuffer, error)
 	PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error)
 	VerifyCICHash(ctx context.Context, idt []byte, expectedCICHash string) error

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -199,6 +199,10 @@ func DiscoverPublicKey(ctx context.Context, headers map[string]any, issuer strin
 		return nil, fmt.Errorf("key %q isn't in JWKS", kid)
 	}
 
+	if key.Algorithm() != jwa.RS256 {
+		return nil, fmt.Errorf("expected alg to be RS256 in JWK with kid %q for OP %q, got %q", kid, issuer, key.Algorithm())
+	}
+
 	pubKey := new(rsa.PublicKey)
 	err = key.Raw(pubKey)
 	if err != nil {

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -130,7 +130,10 @@ func VerifyPKToken(ctx context.Context, pkt *pktoken.PKToken, provider OpenIdPro
 			return fmt.Errorf("failed to get OP public key: %w", err)
 		}
 
-		rsaPubKey := pubKey.(*rsa.PublicKey)
+		rsaPubKey, ok := pubKey.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("expected public key to be a *rsa.PublicKey, got %T", pubKey)
+		}
 
 		err = pkt.VerifyGQSig(rsaPubKey, GQSecurityParameter)
 		if err != nil {

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -103,7 +103,7 @@ func VerifyPKToken(ctx context.Context, pkt *pktoken.PKToken, provider OpenIdPro
 
 	alg, ok := pkt.ProviderAlgorithm()
 	if !ok {
-		return fmt.Errorf("provider signature type missing")
+		return fmt.Errorf("provider algorithm type missing")
 	}
 
 	switch alg {

--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/client/providers"
 	"github.com/openpubkey/openpubkey/gq"
-	"github.com/openpubkey/openpubkey/pktoken"
 	"github.com/openpubkey/openpubkey/util"
 )
 
@@ -33,69 +32,81 @@ func TestClient(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		signer, err := util.GenKeyPair(alg)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		c := client.OpkClient{
-			Op: op,
-		}
-
-		pkt, err := c.OidcAuth(context.Background(), signer, alg, map[string]any{}, tc.gq)
-		if err != nil {
-			t.Fatal(err)
-		}
-		jkt, ok := pkt.Op.PublicHeaders().Get("jkt")
-		if !ok {
-			t.Fatal(fmt.Errorf("missing jkt header"))
-		}
-		var jktstr string
-		if data, ok := jkt.([]uint8); ok {
-			jktstr = string(data)
-		}
-
-		pubkey, err := op.PublicKey(context.Background(), nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		pub, err := jwk.FromRaw(pubkey)
-		if err != nil {
-			t.Fatal(err)
-		}
-		thumbprint, err := pub.Thumbprint(crypto.SHA256)
-		if err != nil {
-			t.Fatal(err)
-		}
-		thumbprintStr := string(util.Base64EncodeForJWT(thumbprint))
-		if jktstr != thumbprintStr {
-			t.Fatal(fmt.Errorf("jkt header %s does not match op thumbprint %s", jkt, thumbprintStr))
-		}
-		sigType, ok := pkt.ProviderSignatureType()
-		if !ok {
-			t.Fatal(fmt.Errorf("missing provider type"))
-		}
-
-		if sigType == pktoken.Gq {
-			// Verify our GQ signature
-			idt, err := pkt.Compact(pkt.Op)
+		t.Run(tc.name, func(t *testing.T) {
+			signer, err := util.GenKeyPair(alg)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			opPubKey, err := op.PublicKey(context.Background(), idt)
-			if err != nil {
-				t.Fatal(err)
+			c := client.OpkClient{
+				Op: op,
 			}
 
-			sv, err := gq.NewSignerVerifier(opPubKey.(*rsa.PublicKey), client.GQSecurityParameter)
+			pkt, err := c.OidcAuth(context.Background(), signer, alg, map[string]any{}, tc.gq)
 			if err != nil {
 				t.Fatal(err)
 			}
-			ok := sv.VerifyJWT(idt)
+			jkt, ok := pkt.Op.PublicHeaders().Get("jkt")
 			if !ok {
-				t.Fatal(fmt.Errorf("error verifying OP GQ signature on PK Token (ID Token invalid)"))
+				t.Fatal("missing jkt header")
 			}
-		}
+			data, ok := jkt.([]byte)
+			if !ok {
+				t.Fatalf("expected jkt header to be a []byte, got %T", jkt)
+			}
+			jktstr := string(data)
+
+			pubkey, err := op.PublicKey(context.Background(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pub, err := jwk.FromRaw(pubkey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			thumbprint, err := pub.Thumbprint(crypto.SHA256)
+			if err != nil {
+				t.Fatal(err)
+			}
+			thumbprintStr := string(util.Base64EncodeForJWT(thumbprint))
+			if jktstr != thumbprintStr {
+				t.Errorf("jkt header %s does not match op thumbprint %s", jkt, thumbprintStr)
+			}
+
+			alg, ok := pkt.ProviderAlgorithm()
+			if !ok {
+				t.Fatal(fmt.Errorf("missing algorithm"))
+			}
+
+			if tc.gq {
+				if alg != gq.GQ256 {
+					t.Errorf("expected GQ256 alg when signing with GQ, got %s", alg)
+				}
+
+				// Verify our GQ signature
+				idt, err := pkt.Compact(pkt.Op)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				opPubKey, err := op.PublicKey(context.Background(), idt)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				sv, err := gq.NewSignerVerifier(opPubKey.(*rsa.PublicKey), client.GQSecurityParameter)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ok := sv.VerifyJWT(idt)
+				if !ok {
+					t.Fatal(fmt.Errorf("error verifying OP GQ signature on PK Token (ID Token invalid)"))
+				}
+			} else {
+				if alg != jwa.RS256 {
+					t.Errorf("expected RS256 alg when not signing with GQ, got %s", alg)
+				}
+			}
+		})
 	}
 }

--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -89,7 +89,7 @@ func TestClient(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				opPubKey, err := op.PublicKey(context.Background(), idt)
+				opPubKey, err := op.PublicKey(context.Background(), nil)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/client/providers/github_actions.go
+++ b/client/providers/github_actions.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"context"
 	"crypto"
-	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,11 +11,7 @@ import (
 	"os"
 
 	"github.com/awnumar/memguard"
-	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/openpubkey/openpubkey/client"
-	oidcclient "github.com/zitadel/oidc/v2/pkg/client"
 )
 
 const githubIssuer = "https://token.actions.githubusercontent.com"
@@ -85,43 +80,8 @@ func (g *GithubOp) VerifyCICHash(ctx context.Context, idt []byte, expectedCICHas
 	return nil
 }
 
-func (g *GithubOp) PublicKey(ctx context.Context, idt []byte) (crypto.PublicKey, error) {
-	j, err := jws.Parse(idt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse JWS: %w", err)
-	}
-	headers := j.Signatures()[0].ProtectedHeaders()
-	alg, kid := headers.Algorithm(), headers.KeyID()
-	if alg != jwa.RS256 {
-		return nil, fmt.Errorf("expected RS256 alg claim, got %s", alg)
-	}
-
-	discConf, err := oidcclient.Discover(githubIssuer, http.DefaultClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call OIDC discovery endpoint: %w", err)
-	}
-
-	jwks, err := jwk.Fetch(ctx, discConf.JwksURI)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch to JWKS: %w", err)
-	}
-
-	key, ok := jwks.LookupKeyID(kid)
-	if !ok {
-		return nil, fmt.Errorf("key %q isn't in JWKS", kid)
-	}
-	keyAlg := key.Algorithm()
-	if keyAlg != jwa.RS256 {
-		return nil, fmt.Errorf("expected RS256 key, got %s", keyAlg)
-	}
-
-	pubKey := new(rsa.PublicKey)
-	err = key.Raw(pubKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode public key: %w", err)
-	}
-
-	return pubKey, err
+func (g *GithubOp) PublicKey(ctx context.Context, headers []byte) (crypto.PublicKey, error) {
+	return client.DiscoverPublicKey(ctx, headers, githubIssuer)
 }
 
 func (g *GithubOp) RequestTokens(ctx context.Context, cicHash string) (*memguard.LockedBuffer, error) {

--- a/client/providers/github_actions.go
+++ b/client/providers/github_actions.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/awnumar/memguard"
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/openpubkey/openpubkey/client"
 )
 
@@ -84,7 +85,7 @@ func (g *GithubOp) Issuer() string {
 	return githubIssuer
 }
 
-func (g *GithubOp) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
+func (g *GithubOp) PublicKey(ctx context.Context, headers jws.Headers) (crypto.PublicKey, error) {
 	return client.DiscoverPublicKey(ctx, headers, githubIssuer)
 }
 

--- a/client/providers/github_actions.go
+++ b/client/providers/github_actions.go
@@ -80,6 +80,10 @@ func (g *GithubOp) VerifyCICHash(ctx context.Context, idt []byte, expectedCICHas
 	return nil
 }
 
+func (g *GithubOp) Issuer() string {
+	return githubIssuer
+}
+
 func (g *GithubOp) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
 	return client.DiscoverPublicKey(ctx, headers, githubIssuer)
 }

--- a/client/providers/github_actions.go
+++ b/client/providers/github_actions.go
@@ -80,7 +80,7 @@ func (g *GithubOp) VerifyCICHash(ctx context.Context, idt []byte, expectedCICHas
 	return nil
 }
 
-func (g *GithubOp) PublicKey(ctx context.Context, headers []byte) (crypto.PublicKey, error) {
+func (g *GithubOp) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
 	return client.DiscoverPublicKey(ctx, headers, githubIssuer)
 }
 

--- a/client/providers/google.go
+++ b/client/providers/google.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/awnumar/memguard"
 	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/util"
 	"github.com/sirupsen/logrus"
@@ -121,7 +122,7 @@ func (g *GoogleOp) Issuer() string {
 	return googleIssuer
 }
 
-func (g *GoogleOp) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
+func (g *GoogleOp) PublicKey(ctx context.Context, headers jws.Headers) (crypto.PublicKey, error) {
 	return client.DiscoverPublicKey(ctx, headers, googleIssuer)
 }
 

--- a/client/providers/google.go
+++ b/client/providers/google.go
@@ -116,8 +116,8 @@ func (g *GoogleOp) VerifyCICHash(ctx context.Context, idt []byte, expectedCICHas
 	return nil
 }
 
-func (g *GoogleOp) PublicKey(ctx context.Context, headersEnc []byte) (crypto.PublicKey, error) {
-	return client.DiscoverPublicKey(ctx, headersEnc, g.Issuer)
+func (g *GoogleOp) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
+	return client.DiscoverPublicKey(ctx, headers, g.Issuer)
 }
 
 func (g *GoogleOp) VerifyNonGQSig(ctx context.Context, idt []byte, expectedNonce string) error {

--- a/client/providers/google.go
+++ b/client/providers/google.go
@@ -23,10 +23,11 @@ var (
 	key = []byte("NotASecureKey123")
 )
 
+const googleIssuer = "https://accounts.google.com"
+
 type GoogleOp struct {
 	ClientID     string
 	ClientSecret string
-	Issuer       string
 	Scopes       []string
 	RedirURIPort string
 	CallbackPath string
@@ -48,7 +49,7 @@ func (g *GoogleOp) RequestTokens(ctx context.Context, cicHash string) (*memguard
 	options = append(options, rp.WithPKCE(cookieHandler))
 
 	provider, err := rp.NewRelyingPartyOIDC(
-		g.Issuer, g.ClientID, g.ClientSecret, g.RedirectURI,
+		g.Issuer(), g.ClientID, g.ClientSecret, g.RedirectURI,
 		g.Scopes, options...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating provider: %w", err)
@@ -116,8 +117,12 @@ func (g *GoogleOp) VerifyCICHash(ctx context.Context, idt []byte, expectedCICHas
 	return nil
 }
 
+func (g *GoogleOp) Issuer() string {
+	return googleIssuer
+}
+
 func (g *GoogleOp) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
-	return client.DiscoverPublicKey(ctx, headers, g.Issuer)
+	return client.DiscoverPublicKey(ctx, headers, googleIssuer)
 }
 
 func (g *GoogleOp) VerifyNonGQSig(ctx context.Context, idt []byte, expectedNonce string) error {
@@ -126,7 +131,7 @@ func (g *GoogleOp) VerifyNonGQSig(ctx context.Context, idt []byte, expectedNonce
 	}
 
 	googleRP, err := rp.NewRelyingPartyOIDC(
-		g.Issuer, g.ClientID, g.ClientSecret, g.RedirectURI, g.Scopes,
+		googleIssuer, g.ClientID, g.ClientSecret, g.RedirectURI, g.Scopes,
 		options...)
 
 	if err != nil {

--- a/client/providers/mocks.go
+++ b/client/providers/mocks.go
@@ -56,7 +56,7 @@ func (m *MockOpenIdProvider) RequestTokens(ctx context.Context, cicHash string) 
 	return memguard.NewBufferFromBytes(signedToken), nil
 }
 
-func (m *MockOpenIdProvider) PublicKey(ctx context.Context, idt []byte) (crypto.PublicKey, error) {
+func (m *MockOpenIdProvider) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
 	return m.signer.Public(), nil
 }
 

--- a/client/providers/mocks.go
+++ b/client/providers/mocks.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/awnumar/memguard"
 	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/lestrrat-go/jwx/v2/jwt/openid"
 	"github.com/openpubkey/openpubkey/util"
@@ -60,7 +61,7 @@ func (m *MockOpenIdProvider) Issuer() string {
 	return MockIssuer
 }
 
-func (m *MockOpenIdProvider) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
+func (m *MockOpenIdProvider) PublicKey(ctx context.Context, headers jws.Headers) (crypto.PublicKey, error) {
 	return m.signer.Public(), nil
 }
 

--- a/client/providers/mocks.go
+++ b/client/providers/mocks.go
@@ -56,6 +56,10 @@ func (m *MockOpenIdProvider) RequestTokens(ctx context.Context, cicHash string) 
 	return memguard.NewBufferFromBytes(signedToken), nil
 }
 
+func (m *MockOpenIdProvider) Issuer() string {
+	return MockIssuer
+}
+
 func (m *MockOpenIdProvider) PublicKey(ctx context.Context, headers map[string]any) (crypto.PublicKey, error) {
 	return m.signer.Public(), nil
 }

--- a/cosigner/mfa/cosigner.go
+++ b/cosigner/mfa/cosigner.go
@@ -61,5 +61,5 @@ func (c *Cosigner) Cosign(pkt *pktoken.PKToken) error {
 	}
 
 	// Now that our mfa has authenticated the user, we can add our signature
-	return pkt.Sign(pktoken.Cos, c.signer, c.alg, headers)
+	return pkt.Sign(pktoken.COS, c.signer, c.alg, headers)
 }

--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -28,7 +28,6 @@ var (
 	clientID = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
 	// The clientSecret was intentionally checked in for the purposes of this example,. It holds no power. Do not report as a security issue
 	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
-	issuer       = "https://accounts.google.com"
 	scopes       = []string{"openid profile email"}
 	redirURIPort = "3000"
 	callbackPath = "/login-callback"
@@ -85,7 +84,6 @@ func login(outputDir string, alg jwa.KeyAlgorithm, signGQ bool) error {
 		Op: &providers.GoogleOp{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
-			Issuer:       issuer,
 			Scopes:       scopes,
 			RedirURIPort: redirURIPort,
 			CallbackPath: callbackPath,

--- a/examples/mfa/example.go
+++ b/examples/mfa/example.go
@@ -19,7 +19,6 @@ var (
 	clientID = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
 	// The clientSecret was intentionally checked in for the purposes of this example,. It holds no power. Do not report as a security issue
 	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
-	issuer       = "https://accounts.google.com"
 	scopes       = []string{"openid profile email"}
 	redirURIPort = "3000"
 	callbackPath = "/login-callback"
@@ -36,7 +35,6 @@ func main() {
 	provider := &providers.GoogleOp{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Issuer:       issuer,
 		Scopes:       scopes,
 		RedirURIPort: redirURIPort,
 		CallbackPath: callbackPath,

--- a/examples/ssh/opkssh/cli.go
+++ b/examples/ssh/opkssh/cli.go
@@ -25,7 +25,6 @@ var (
 	requiredAudience = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
 	// The clientSecret was intentionally checked in for the purposes of this example,. It holds no power. Do not report as a security issue
 	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
-	issuer       = "https://accounts.google.com"
 	scopes       = []string{"openid profile email"}
 	redirURIPort = "3000"
 	callbackPath = "/login-callback"
@@ -43,7 +42,6 @@ func main() {
 	op := providers.GoogleOp{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Issuer:       issuer,
 		Scopes:       scopes,
 		RedirURIPort: redirURIPort,
 		CallbackPath: callbackPath,

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -114,7 +114,7 @@ func OriginalJWTHeaders(jwt []byte) ([]byte, error) {
 	headers := token.Signatures()[0].ProtectedHeaders()
 
 	if headers.Algorithm() != GQ256 {
-		return nil, fmt.Errorf("TODO")
+		return nil, fmt.Errorf("expected GQ256 alg, got %s", headers.Algorithm())
 	}
 
 	origHeaders := []byte(headers.KeyID())

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -136,8 +136,14 @@ func createOIDCToken(oidcPrivKey *rsa.PrivateKey, audience string) ([]byte, erro
 	alg := jwa.RS256 // RSASSA-PKCS-v1.5 using SHA-256
 
 	oidcHeader := jws.NewHeaders()
-	oidcHeader.Set("alg", alg.String())
-	oidcHeader.Set("typ", "JWT")
+	err := oidcHeader.Set(jws.AlgorithmKey, alg)
+	if err != nil {
+		return nil, err
+	}
+	err = oidcHeader.Set(jws.TypeKey, "JWT")
+	if err != nil {
+		return nil, err
+	}
 
 	oidcPayload := map[string]any{
 		"sub": "1",

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -1,7 +1,6 @@
 package gq
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
@@ -13,7 +12,7 @@ import (
 	"github.com/openpubkey/openpubkey/util"
 )
 
-func TestProveVerify(t *testing.T) {
+func TestSignVerifyJWT(t *testing.T) {
 	oidcPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatal(err)
@@ -128,7 +127,7 @@ func modifyTokenPayload(token []byte, audience string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	newToken := bytes.Join([][]byte{headers, util.Base64EncodeForJWT(modifiedPayload), signature}, []byte{'.'})
+	newToken := util.JoinJWTSegments(headers, util.Base64EncodeForJWT(modifiedPayload), signature)
 	return newToken, nil
 }
 

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -3,7 +3,6 @@ package gq
 import (
 	"crypto/rand"
 	"encoding/json"
-	"fmt"
 	"math/big"
 
 	"filippo.io/bigmod"
@@ -81,10 +80,19 @@ func (sv *signerVerifier) SignJWT(jwt []byte) ([]byte, error) {
 	signingPayload := append(origHeaders, []byte(".")...)
 	signingPayload = append(signingPayload, payload...)
 
-	headers := make(map[string]any)
-	headers["alg"] = "GQ256"
-	headers["typ"] = "JWT"
-	headers["orig"] = string(origHeaders)
+	headers := jws.NewHeaders()
+	err = headers.Set(jws.AlgorithmKey, GQ256)
+	if err != nil {
+		return nil, err
+	}
+	err = headers.Set(jws.TypeKey, "JWT")
+	if err != nil {
+		return nil, err
+	}
+	err = headers.Set(jws.KeyIDKey, string(origHeaders))
+	if err != nil {
+		return nil, err
+	}
 
 	headersJSON, err := json.Marshal(headers)
 	if err != nil {
@@ -118,8 +126,6 @@ func (sv *signerVerifier) SignJWT(jwt []byte) ([]byte, error) {
 	gqToken = append(gqToken, payload...)
 	gqToken = append(gqToken, '.')
 	gqToken = append(gqToken, gqSig...)
-
-	fmt.Println(string(gqToken))
 
 	return gqToken, nil
 }

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -77,8 +77,7 @@ func (sv *signerVerifier) SignJWT(jwt []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	signingPayload := append(origHeaders, []byte(".")...)
-	signingPayload = append(signingPayload, payload...)
+	signingPayload := util.JoinJWTSegments(origHeaders, payload)
 
 	headers := jws.NewHeaders()
 	err = headers.Set(jws.AlgorithmKey, GQ256)
@@ -122,10 +121,7 @@ func (sv *signerVerifier) SignJWT(jwt []byte) ([]byte, error) {
 	}
 
 	// Now make a new GQ-signed token
-	gqToken := append(headersEnc, '.')
-	gqToken = append(gqToken, payload...)
-	gqToken = append(gqToken, '.')
-	gqToken = append(gqToken, gqSig...)
+	gqToken := util.JoinJWTSegments(headersEnc, payload, gqSig)
 
 	return gqToken, nil
 }

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/openpubkey/openpubkey/util"
 )
 
@@ -74,10 +75,20 @@ func (sv *signerVerifier) Verify(proof []byte, identity []byte, message []byte) 
 }
 
 func (sv *signerVerifier) VerifyJWT(jwt []byte) bool {
-	signingPayload, signature, err := parseJWT(jwt)
+	origHeaders, err := OriginalJWTHeaders(jwt)
 	if err != nil {
 		return false
 	}
+
+	_, payload, signature, err := jws.SplitCompact(jwt)
+	if err != nil {
+		return false
+	}
+
+	signingPayload := append([]byte(origHeaders), []byte(".")...)
+	signingPayload = append(signingPayload, payload...)
+
+	fmt.Println(string(signingPayload))
 
 	return sv.Verify(signature, signingPayload, signingPayload)
 }

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -88,8 +88,6 @@ func (sv *signerVerifier) VerifyJWT(jwt []byte) bool {
 	signingPayload := append([]byte(origHeaders), []byte(".")...)
 	signingPayload = append(signingPayload, payload...)
 
-	fmt.Println(string(signingPayload))
-
 	return sv.Verify(signature, signingPayload, signingPayload)
 }
 

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -85,8 +85,7 @@ func (sv *signerVerifier) VerifyJWT(jwt []byte) bool {
 		return false
 	}
 
-	signingPayload := append([]byte(origHeaders), []byte(".")...)
-	signingPayload = append(signingPayload, payload...)
+	signingPayload := util.JoinJWTSegments(origHeaders, payload)
 
 	return sv.Verify(signature, signingPayload, signingPayload)
 }

--- a/pktoken/clientinstance/claims.go
+++ b/pktoken/clientinstance/claims.go
@@ -29,7 +29,7 @@ func NewClaims(publicKey jwk.Key, claims map[string]any) (*Claims, error) {
 	}
 
 	// Make sure no claims are using our reserved values
-	for _, reserved := range []string{"alg", "upk", "rz"} {
+	for _, reserved := range []string{"alg", "upk", "rz", "typ"} {
 		if _, ok := claims[reserved]; ok {
 			return nil, fmt.Errorf("use of reserved header name, %s, in additional headers", reserved)
 		}
@@ -41,6 +41,7 @@ func NewClaims(publicKey jwk.Key, claims map[string]any) (*Claims, error) {
 	}
 
 	// Assign required values
+	claims["typ"] = "CIC"
 	claims["alg"] = publicKey.Algorithm().String()
 	claims["upk"] = publicKey
 	claims["rz"] = rand

--- a/pktoken/mocks/pktoken.go
+++ b/pktoken/mocks/pktoken.go
@@ -62,5 +62,5 @@ func GenerateMockPKTokenWithEmail(signingKey crypto.Signer, alg jwa.KeyAlgorithm
 	}
 
 	// Combine two tokens into a PK Token
-	return pktoken.New(idToken.Bytes(), cicToken, false)
+	return pktoken.New(idToken.Bytes(), cicToken)
 }

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -2,6 +2,7 @@ package pktoken
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"encoding/json"
 	"fmt"
@@ -15,15 +16,12 @@ import (
 	_ "golang.org/x/crypto/sha3"
 )
 
-const sigTypeHeader = "sig_type"
-
 type SignatureType string
 
 const (
-	Oidc SignatureType = "oidc"
-	Gq   SignatureType = "oidc_gq"
-	Cic  SignatureType = "cic"
-	Cos  SignatureType = "cos"
+	OIDC SignatureType = "JWT"
+	CIC  SignatureType = "CIC"
+	COS  SignatureType = "COS"
 )
 
 type Signature = jws.Signature
@@ -48,22 +46,26 @@ func (p *PKToken) AddJKTHeader(opKey crypto.PublicKey) error {
 	if err != nil {
 		return fmt.Errorf("failed to calculate thumbprint: %w", err)
 	}
-	return p.Op.PublicHeaders().Set("jkt", util.Base64EncodeForJWT(thumbprint))
+	headers := p.Op.PublicHeaders()
+	if headers == nil {
+		headers = jws.NewHeaders()
+	}
+	err = headers.Set("jkt", util.Base64EncodeForJWT(thumbprint))
+	if err != nil {
+		return fmt.Errorf("failed to set jkt claim: %w", err)
+	}
+	p.Op.SetPublicHeaders(headers)
+	return nil
 }
 
-func New(idToken []byte, cicToken []byte, isGQ bool) (*PKToken, error) {
+func New(idToken []byte, cicToken []byte) (*PKToken, error) {
 	pkt := &PKToken{}
 
-	sigType := Oidc
-	if isGQ {
-		sigType = Gq
-	}
-
-	if err := pkt.AddSignature(idToken, sigType); err != nil {
+	if err := pkt.AddSignature(idToken, OIDC); err != nil {
 		return nil, err
 	}
 
-	if err := pkt.AddSignature(cicToken, Cic); err != nil {
+	if err := pkt.AddSignature(cicToken, CIC); err != nil {
 		return nil, err
 	}
 
@@ -112,18 +114,22 @@ func (p *PKToken) AddSignature(token []byte, sigType SignatureType) error {
 		return fmt.Errorf("payload in the GQ token (%s) does not match the existing payload in the PK Token (%s)", p.Payload, message.Payload())
 	}
 
-	public := jws.NewHeaders()
-	if err := public.Set(sigTypeHeader, string(sigType)); err != nil {
-		return err
+	signature := message.Signatures()[0]
+
+	if sigType == CIC || sigType == COS {
+		protected := signature.ProtectedHeaders()
+		if err := protected.Set(jws.TypeKey, string(sigType)); err != nil {
+			return err
+		}
+		signature = signature.SetProtectedHeaders(protected)
 	}
-	signature := message.Signatures()[0].SetPublicHeaders(public)
 
 	switch sigType {
-	case Oidc, Gq:
+	case OIDC:
 		p.Op = signature
-	case Cic:
+	case CIC:
 		p.Cic = signature
-	case Cos:
+	case COS:
 		p.Cos = signature
 	default:
 		return fmt.Errorf("unrecognized signature type: %s", string(sigType))
@@ -131,13 +137,13 @@ func (p *PKToken) AddSignature(token []byte, sigType SignatureType) error {
 	return nil
 }
 
-func (p *PKToken) ProviderSignatureType() (SignatureType, bool) {
-	sigType, ok := p.Op.PublicHeaders().Get(sigTypeHeader)
+func (p *PKToken) ProviderAlgorithm() (jwa.SignatureAlgorithm, bool) {
+	alg, ok := p.Op.ProtectedHeaders().Get(jws.AlgorithmKey)
 	if !ok {
-		return "", ok
+		return "", false
 	}
 
-	return SignatureType(sigType.(string)), true
+	return alg.(jwa.SignatureAlgorithm), true
 }
 
 func (p *PKToken) Compact(sig *Signature) ([]byte, error) {
@@ -192,31 +198,39 @@ func (p *PKToken) UnmarshalJSON(data []byte) error {
 	cicCount := 0
 	cosCount := 0
 	for _, signature := range parsed.Signatures() {
-		sigHeader, ok := signature.PublicHeaders().Get(sigTypeHeader)
-		if !ok {
-			return fmt.Errorf(`pk token signature is missing required "%s" header as public header`, sigTypeHeader)
+		// for some reason the unmarshaled signatures have empty non-nil
+		// public headers. set them to nil instead.
+		public := signature.PublicHeaders()
+		pubMap, _ := public.AsMap(context.Background())
+		if len(pubMap) == 0 {
+			signature.SetPublicHeaders(nil)
 		}
 
-		sigHeaderString, ok := sigHeader.(string)
+		protected := signature.ProtectedHeaders()
+		typeHeader, ok := protected.Get(jws.TypeKey)
 		if !ok {
-			return fmt.Errorf(`provided "%s" is of wrong type, expected string`, sigTypeHeader)
+			// TODO: default to OIDC?
+			return fmt.Errorf("missing typ header")
+		}
+		sigTypeStr, ok := typeHeader.(string)
+		if !ok {
+			return fmt.Errorf(`provided "%s" is of wrong type, expected string`, jws.TypeKey)
 		}
 
-		switch SignatureType(sigHeaderString) {
-		case Oidc:
+		sigType := SignatureType(sigTypeStr)
+
+		switch sigType {
+		case OIDC:
 			opCount += 1
 			p.Op = signature
-		case Gq:
-			opCount += 1
-			p.Op = signature
-		case Cic:
+		case CIC:
 			cicCount += 1
 			p.Cic = signature
-		case Cos:
+		case COS:
 			cosCount += 1
 			p.Cos = signature
 		default:
-			return fmt.Errorf("unrecognized signature types: %s", sigHeaderString)
+			return fmt.Errorf("unrecognized signature type: %s", sigType)
 		}
 	}
 

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -207,17 +207,20 @@ func (p *PKToken) UnmarshalJSON(data []byte) error {
 		}
 
 		protected := signature.ProtectedHeaders()
-		typeHeader, ok := protected.Get(jws.TypeKey)
-		if !ok {
-			// TODO: default to OIDC?
-			return fmt.Errorf("missing typ header")
-		}
-		sigTypeStr, ok := typeHeader.(string)
-		if !ok {
-			return fmt.Errorf(`provided "%s" is of wrong type, expected string`, jws.TypeKey)
-		}
+		var sigType SignatureType
 
-		sigType := SignatureType(sigTypeStr)
+		typeHeader, ok := protected.Get(jws.TypeKey)
+		if ok {
+			sigTypeStr, ok := typeHeader.(string)
+			if !ok {
+				return fmt.Errorf(`provided "%s" is of wrong type, expected string`, jws.TypeKey)
+			}
+
+			sigType = SignatureType(sigTypeStr)
+		} else {
+			// missing typ claim, assuming this is from the OIDC provider
+			sigType = OIDC
+		}
 
 		switch sigType {
 		case OIDC:

--- a/util/base64.go
+++ b/util/base64.go
@@ -4,20 +4,23 @@ import (
 	"encoding/base64"
 )
 
+var standardEncoding = base64.StdEncoding.Strict()
+var rawURLEncoding = base64.RawURLEncoding.Strict()
+
 func Base64Encode(decoded []byte) []byte {
-	return base64Encode(decoded, base64.StdEncoding.Strict())
+	return base64Encode(decoded, standardEncoding)
 }
 
 func Base64Decode(encoded []byte) ([]byte, error) {
-	return base64Decode(encoded, base64.StdEncoding.Strict())
+	return base64Decode(encoded, standardEncoding)
 }
 
 func Base64EncodeForJWT(decoded []byte) []byte {
-	return base64Encode(decoded, base64.RawURLEncoding.Strict())
+	return base64Encode(decoded, rawURLEncoding)
 }
 
 func Base64DecodeForJWT(encoded []byte) ([]byte, error) {
-	return base64Decode(encoded, base64.RawURLEncoding.Strict())
+	return base64Decode(encoded, rawURLEncoding)
 }
 
 func base64Encode(decoded []byte, encoding *base64.Encoding) []byte {

--- a/util/bytes.go
+++ b/util/bytes.go
@@ -1,0 +1,11 @@
+package util
+
+import "bytes"
+
+func JoinJWTSegments(segments ...[]byte) []byte {
+	return JoinBytes('.', segments...)
+}
+
+func JoinBytes(sep byte, things ...[]byte) []byte {
+	return bytes.Join(things, []byte{sep})
+}


### PR DESCRIPTION
Closes #15.

For GQ signatures, we take the original ID token from the OIDC provider and replace the header. The new header is the same as the original with two changes:

1. The `alg` claim is set to `GQ256`
2. The `kid` claim is set to the original header value from the ID token. This value is taken directly from the JWT token signing payload (raw base64 encoded)

The `alg` value gives us an easy way to identify the GQ signature from a JWS containing multiple signatures. The `kid` claim allows us to recreate the original signing payload in order to verify the signature.

For example, an ID token header of
```json
{"alg":"RS256","typ":"JWT"}
```
would be replaced with a new header:
```json
{"alg":"GQ256","kid":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9","typ":"JWT"}
```