### PR TITLE
Run unit tests against ISO/IEC 14888-2:2008 GQ test vectors

### DIFF
--- a/gq/benchmark_test.go
+++ b/gq/benchmark_test.go
@@ -1,12 +1,10 @@
-package gq_test
+package gq
 
 import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
 	"testing"
-
-	"github.com/openpubkey/openpubkey/gq"
 )
 
 var result error
@@ -27,9 +25,9 @@ func BenchmarkSigning(b *testing.B) {
 	// Reset the benchmark timer to exclude setup time
 	b.ResetTimer()
 
-	var signerVerifier gq.SignerVerifier
+	var signerVerifier SignerVerifier
 	for i := 0; i < b.N; i++ {
-		signerVerifier, err = gq.NewSignerVerifier(matrix[i].rsaPublicKey, 256)
+		signerVerifier, err = NewSignerVerifier(matrix[i].rsaPublicKey, 256)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -51,7 +49,7 @@ func BenchmarkVerifying(b *testing.B) {
 	// Generate signatures using matrix
 	gqSignedTokens := [][]byte{}
 	for i := 0; i < b.N; i++ {
-		signerVerifier, err := gq.NewSignerVerifier(matrix[i].rsaPublicKey, 256)
+		signerVerifier, err := NewSignerVerifier(matrix[i].rsaPublicKey, 256)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -68,7 +66,7 @@ func BenchmarkVerifying(b *testing.B) {
 
 	var ok bool
 	for i := 0; i < b.N; i++ {
-		signerVerifier, err := gq.NewSignerVerifier(matrix[i].rsaPublicKey, 256)
+		signerVerifier, err := NewSignerVerifier(matrix[i].rsaPublicKey, 256)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -78,10 +78,10 @@ func bytesForBits(bits int) int {
 
 var hash = func(byteCount int, data ...[]byte) ([]byte, error) {
 	rng := sha3.NewShake256()
-
 	for _, d := range data {
 		rng.Write(d)
 	}
+
 	return randomBytes(rng, byteCount)
 }
 

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -2,7 +2,6 @@ package gq
 
 import (
 	"crypto/rsa"
-	"crypto/sha1"
 	"io"
 	"math/big"
 
@@ -10,8 +9,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"golang.org/x/crypto/sha3"
 )
-
-var useSha3 = true
 
 // Signer allows for creating GQ1 signatures messages.
 type Signer interface {
@@ -79,22 +76,13 @@ func bytesForBits(bits int) int {
 	return (bits + 7) / 8
 }
 
-// FIXME: should probably make this a var
-func hash(byteCount int, data ...[]byte) ([]byte, error) {
-	if useSha3 {
-		rng := sha3.NewShake256()
+var hash = func(byteCount int, data ...[]byte) ([]byte, error) {
+	rng := sha3.NewShake256()
 
-		for _, d := range data {
-			rng.Write(d)
-		}
-		return randomBytes(rng, byteCount)
-	} else {
-		rng := sha1.New()
-		for _, d := range data {
-			rng.Write(d)
-		}
-		return rng.Sum(nil)[:byteCount], nil
+	for _, d := range data {
+		rng.Write(d)
 	}
+	return randomBytes(rng, byteCount)
 
 }
 

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -80,7 +80,7 @@ func bytesForBits(bits int) int {
 }
 
 // FIXME:
-func gqHash(byteCount int, data ...[]byte) ([]byte, error) {
+func hash(byteCount int, data ...[]byte) ([]byte, error) {
 	if useSha3 {
 		rng := sha3.NewShake256()
 
@@ -89,12 +89,10 @@ func gqHash(byteCount int, data ...[]byte) ([]byte, error) {
 		}
 		return randomBytes(rng, byteCount)
 	} else {
-		//
 		rng := sha1.New()
 		for _, d := range data {
 			rng.Write(d)
 		}
-		//
 		return rng.Sum(nil)[:byteCount], nil
 	}
 

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -83,7 +83,6 @@ var hash = func(byteCount int, data ...[]byte) ([]byte, error) {
 		rng.Write(d)
 	}
 	return randomBytes(rng, byteCount)
-
 }
 
 func randomBytes(rng io.Reader, byteCount int) ([]byte, error) {

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -79,7 +79,7 @@ func bytesForBits(bits int) int {
 	return (bits + 7) / 8
 }
 
-// FIXME:
+// FIXME: should probably make this a var
 func hash(byteCount int, data ...[]byte) ([]byte, error) {
 	if useSha3 {
 		rng := sha3.NewShake256()

--- a/gq/gq_iso_test.go
+++ b/gq/gq_iso_test.go
@@ -29,8 +29,6 @@ var svISO signerVerifier
 
 // Test our signer using the values specified in ISO/IEC 14888-2:2008
 func TestSignerISO(t *testing.T) {
-	initializeISOValues(t)
-
 	// The test vector specifies that h(W||M) use SHA-1
 	h := hash
 	hash = sha1Hash
@@ -62,8 +60,6 @@ func TestSignerISO(t *testing.T) {
 
 // Test our verifier using the values specified in ISO/IEC 14888-2:2008
 func TestVerifierISO(t *testing.T) {
-	initializeISOValues(t)
-
 	// The test vector specifies that h(W||M) use SHA-1
 	h := hash
 	hash = sha1Hash
@@ -87,37 +83,43 @@ func TestVerifierISO(t *testing.T) {
 	}
 }
 
-func initializeISOValues(t *testing.T) {
+func init() {
 	vBytes, err := hex.DecodeString(vHex)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 	v := new(big.Int).SetBytes(vBytes)
 
 	nBytes, err := hex.DecodeString(nHex)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nBytes))
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
-	svISO = signerVerifier{n, v, 128, 10, 1}
+	svISO = signerVerifier{
+		n:      n,
+		v:      v,
+		nBytes: 128,
+		vBytes: 10,
+		t:      1,
+	}
 
 	sigISO, err = hex.DecodeString(sigHex)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
 	qISO, err = hex.DecodeString(qHex)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
 	idISO, err = hex.DecodeString(idHex)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 }
 
@@ -127,7 +129,7 @@ var pssEncodedId = func(k int, data []byte) []byte {
 }
 
 var hardcodedRandomISO = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
-	ys := make([]*bigmod.Nat, t)
+	ys := make([]*bigmod.Nat, 1)
 
 	rRaw, err := hex.DecodeString(rHex)
 	if err != nil {

--- a/gq/gq_iso_test.go
+++ b/gq/gq_iso_test.go
@@ -1,0 +1,162 @@
+package gq
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"filippo.io/bigmod"
+	"github.com/openpubkey/openpubkey/util"
+)
+
+// The test vector specifies hex values for each of the signature scheme's data
+// elements, as well as the expected content of the signature
+const nHex = "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1"
+const vHex = "010000000000000000000D"
+const qHex = "3BED38CEBB1219BC068774E0E2655CDEF67FE547BCF2D9FA9FE167B1E63B2F101A1483D38A8F24EDE365A3E44F4F10ADECEA7B30D042C14C162477B8184AE6CFAA78441B1FDFB0B223ABCD528B61F313D859FCF9C26FCAF9E4D9DA9BA83E9D2FDA041E8CCBF90056C31D654B546C1A7F6729A8DD8E68512F39E3B6F07959CE61"
+const idHex = "416C657820416D706C65"
+const gHex = "3E641A22D0D0747D4ACC71884D3DFF2B2ADFDC1703B5A74EFD8333AB8C4377BB2A9B48E707F73409ABFBCD2DED69F52B16A145CE062FE6BD712C1952110DFB2316C5F3F321922ED375A4DEB8C41FA79BCAD86B0EA0D8FF02C9D0D5911BFF1E87DBCF073F71F18C08EB944AE84883A1E13FB1DEA123B5B1EFEA2A92635BD5D88F"
+const rHex = "487CDB0041BEED0323FDD3DEC8542584FA0E6CB990FAD5878DB34E9BEDDC95B65D22790C108E218407ED7F7D686657BAB5A28EF81C2E24985B56E37D9934E195A38A835CC02CEE8EBA2F56C87663E332976F5A3720DACA120BCD3DF0AEF6FD78582EBFCEE6D05E06172A871EAB0E8F5FC22DDB600F541B87CF8E147358374406"
+const sigHex = "99394F1D15924C0374CF80C7274CD9F232903A6423D9327156F69743EAEF03E1EFEDFDA8474C97F6570D9EF53C6CE2AE2BA68D01FFF9AA82068214BCD775B95CC297DDC38A63741AB3166B58275E0FB728D26DB18A2C3F14B621CF3863F8648B3149FE896348BE73D37E2F06E6E26C84C044984C09C658300B58EC2383E3B0A1F1390D62B772A69F37B5"
+
+var mISO = []byte("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopqo")
+var sigISO []byte
+var qISO []byte
+var idISO []byte
+var svISO signerVerifier
+
+// Test our signer using the values specified in ISO/IEC 14888-2:2008
+func TestSignerISO(t *testing.T) {
+	initializeISOValues(t)
+
+	// The test vector specifies that h(W||M) use SHA-1
+	h := hash
+	hash = sha1Hash
+
+	// Instead of a true random value for r, use the value from the test vector
+	rn := randomNumbers
+	randomNumbers = hardcodedRandomISO
+
+	// restore default function definitions after the test
+	defer func() {
+		hash = h
+		randomNumbers = rn
+	}()
+
+	encodedSig, err := svISO.Sign(qISO, mISO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := util.Base64DecodeForJWT(encodedSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(sig, sigISO) {
+		t.Fatal("Signature does not match expected value")
+	}
+}
+
+// Test our verifier using the values specified in ISO/IEC 14888-2:2008
+func TestVerifierISO(t *testing.T) {
+	initializeISOValues(t)
+
+	// The test vector specifies that h(W||M) use SHA-1
+	h := hash
+	hash = sha1Hash
+
+	// The test vector formats Id with PSS. Instead of implementing this
+	// encoding ourselves, we hardcode the value for G given in the standard
+	ep := encodePKCS1v15
+	encodePKCS1v15 = pssEncodedId
+
+	// restore default function definitions after the test
+	defer func() {
+		hash = h
+		encodePKCS1v15 = ep
+	}()
+
+	encodedSigISO := util.Base64EncodeForJWT(sigISO)
+	ok := svISO.Verify(encodedSigISO, idISO, mISO)
+
+	if !ok {
+		t.Fatal("signature verification failed")
+	}
+}
+
+func initializeISOValues(t *testing.T) {
+	vBytes, err := hexToBytes(vHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := new(big.Int).SetBytes(vBytes)
+
+	nBytes, err := hexToBytes(nHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svISO = signerVerifier{n, v, 128, 10, 1}
+
+	sigISO, err = hexToBytes(sigHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qISO, err = hexToBytes(qHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idISO, err = hexToBytes(idHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+var pssEncodedId = func(k int, data []byte) []byte {
+	em, _ := hexToBytes(gHex)
+	return em
+}
+
+var hardcodedRandomISO = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
+	ys := make([]*bigmod.Nat, t)
+
+	rRaw, err := hexToBytes(rHex)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := bigmod.NewNat().SetBytes(rRaw, n)
+	if err != nil {
+		return nil, err
+	}
+
+	ys[0] = r
+	return ys, nil
+}
+
+var sha1Hash = func(byteCount int, data ...[]byte) ([]byte, error) {
+	hash := sha1.New()
+	for _, d := range data {
+		hash.Write(d)
+	}
+	return hash.Sum(nil)[:byteCount], nil
+}
+
+func hexToBytes(hexStr string) ([]byte, error) {
+	bytes := make([]byte, hex.DecodedLen(len(hexStr)))
+	_, err := hex.Decode(bytes, []byte(hexStr))
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}

--- a/gq/gq_iso_test.go
+++ b/gq/gq_iso_test.go
@@ -88,13 +88,13 @@ func TestVerifierISO(t *testing.T) {
 }
 
 func initializeISOValues(t *testing.T) {
-	vBytes, err := hexToBytes(vHex)
+	vBytes, err := hex.DecodeString(vHex)
 	if err != nil {
 		t.Fatal(err)
 	}
 	v := new(big.Int).SetBytes(vBytes)
 
-	nBytes, err := hexToBytes(nHex)
+	nBytes, err := hex.DecodeString(nHex)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,31 +105,31 @@ func initializeISOValues(t *testing.T) {
 
 	svISO = signerVerifier{n, v, 128, 10, 1}
 
-	sigISO, err = hexToBytes(sigHex)
+	sigISO, err = hex.DecodeString(sigHex)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	qISO, err = hexToBytes(qHex)
+	qISO, err = hex.DecodeString(qHex)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	idISO, err = hexToBytes(idHex)
+	idISO, err = hex.DecodeString(idHex)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 var pssEncodedId = func(k int, data []byte) []byte {
-	em, _ := hexToBytes(gHex)
+	em, _ := hex.DecodeString(gHex)
 	return em
 }
 
 var hardcodedRandomISO = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
 	ys := make([]*bigmod.Nat, t)
 
-	rRaw, err := hexToBytes(rHex)
+	rRaw, err := hex.DecodeString(rHex)
 	if err != nil {
 		return nil, err
 	}
@@ -149,14 +149,4 @@ var sha1Hash = func(byteCount int, data ...[]byte) ([]byte, error) {
 		hash.Write(d)
 	}
 	return hash.Sum(nil)[:byteCount], nil
-}
-
-func hexToBytes(hexStr string) ([]byte, error) {
-	bytes := make([]byte, hex.DecodedLen(len(hexStr)))
-	_, err := hex.Decode(bytes, []byte(hexStr))
-	if err != nil {
-		return nil, err
-	}
-
-	return bytes, nil
 }

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -4,48 +4,14 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
-	"math/big"
 	"testing"
 	"time"
 
-	"filippo.io/bigmod"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/openpubkey/openpubkey/util"
 )
-
-var vIso = new(big.Int).SetBytes([]byte(hexToBytes(nil, "010000000000000000000D")))
-var messageIso = []byte("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopqo")
-var sigISO = hexToBytes(nil, "99394F1D15924C0374CF80C7274CD9F232903A6423D9327156F69743EAEF03E1EFEDFDA8474C97F6570D9EF53C6CE2AE2BA68D01FFF9AA82068214BCD775B95CC297DDC38A63741AB3166B58275E0FB728D26DB18A2C3F14B621CF3863F8648B3149FE896348BE73D37E2F06E6E26C84C044984C09C658300B58EC2383E3B0A1F1390D62B772A69F37B5")
-
-var pssEncodedId = func(k int, data []byte) []byte {
-	return hexToBytes(nil, "3E641A22D0D0747D4ACC71884D3DFF2B2ADFDC1703B5A74EFD8333AB8C4377BB2A9B48E707F73409ABFBCD2DED69F52B16A145CE062FE6BD712C1952110DFB2316C5F3F321922ED375A4DEB8C41FA79BCAD86B0EA0D8FF02C9D0D5911BFF1E87DBCF073F71F18C08EB944AE84883A1E13FB1DEA123B5B1EFEA2A92635BD5D88F")
-}
-
-var randomISO = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
-	ys := make([]*bigmod.Nat, t)
-
-	rRaw := hexToBytes(nil, "487CDB0041BEED0323FDD3DEC8542584FA0E6CB990FAD5878DB34E9BEDDC95B65D22790C108E218407ED7F7D686657BAB5A28EF81C2E24985B56E37D9934E195A38A835CC02CEE8EBA2F56C87663E332976F5A3720DACA120BCD3DF0AEF6FD78582EBFCEE6D05E06172A871EAB0E8F5FC22DDB600F541B87CF8E147358374406")
-	r, err := bigmod.NewNat().SetBytes(rRaw, n)
-	if err != nil {
-		return nil, err
-	}
-
-	ys[0] = r
-	return ys, nil
-}
-
-// TODO:
-var sha1Hash = func(byteCount int, data ...[]byte) ([]byte, error) {
-	rng := sha1.New()
-	for _, d := range data {
-		rng.Write(d)
-	}
-	return rng.Sum(nil)[:byteCount], nil
-}
 
 func TestProveVerify(t *testing.T) {
 	oidcPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -71,59 +37,6 @@ func TestProveVerify(t *testing.T) {
 	}
 
 	ok := signerVerifier.VerifyJWT(gqToken)
-	if !ok {
-		t.Fatal("signature verification failed")
-	}
-}
-
-func TestSignerISO(t *testing.T) {
-	h := hash
-	hash = sha1Hash
-
-	rn := randomNumbers
-	randomNumbers = randomISO
-
-	defer func() {
-		hash = h
-		randomNumbers = rn
-	}()
-
-	sv := signerVerifierISO(t)
-	Q := hexToBytes(t, "3BED38CEBB1219BC068774E0E2655CDEF67FE547BCF2D9FA9FE167B1E63B2F101A1483D38A8F24EDE365A3E44F4F10ADECEA7B30D042C14C162477B8184AE6CFAA78441B1FDFB0B223ABCD528B61F313D859FCF9C26FCAF9E4D9DA9BA83E9D2FDA041E8CCBF90056C31D654B546C1A7F6729A8DD8E68512F39E3B6F07959CE61")
-
-	encodedSig, err := sv.Sign(Q, messageIso)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	sig, err := util.Base64DecodeForJWT(encodedSig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(sig, sigISO) {
-		t.Fatal("Signature does not match expected value")
-	}
-}
-
-func TestVerifierISO(t *testing.T) {
-	h := hash
-	hash = sha1Hash
-
-	e := encodePKCS1v15
-	encodePKCS1v15 = pssEncodedId
-
-	defer func() {
-		hash = h
-		encodePKCS1v15 = e
-	}()
-
-	sv := signerVerifierISO(t)
-	encodedSig := util.Base64EncodeForJWT(sigISO)
-	id := hexToBytes(t, "416C657820416D706C65")
-
-	ok := sv.Verify(encodedSig, id, messageIso)
-
 	if !ok {
 		t.Fatal("signature verification failed")
 	}
@@ -250,34 +163,4 @@ func createOIDCToken(oidcPrivKey *rsa.PrivateKey, audience string) ([]byte, erro
 	}
 
 	return jwt, nil
-}
-
-// FIXME: not sure about passing t here...
-func hexToBytes(t *testing.T, hexStr string) []byte {
-	bytes := make([]byte, hex.DecodedLen(len(hexStr)))
-	_, err := hex.Decode(bytes, []byte(hexStr))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return bytes
-}
-
-// TODO:
-func signerVerifierISO(t *testing.T) signerVerifier {
-	nBytes := hexToBytes(t, "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1")
-	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nBytes))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	nLen := n.BitLen()
-	vLen := vIso.BitLen() - 1
-	return signerVerifier{
-		n:      n,
-		v:      vIso,
-		t:      1,
-		nBytes: bytesForBits(nLen),
-		vBytes: bytesForBits(vLen),
-	}
 }

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
@@ -18,6 +19,33 @@ import (
 
 var vIso = new(big.Int).SetBytes([]byte(hexToBytes(nil, "010000000000000000000D")))
 var messageIso = []byte("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopqo")
+var sigISO = hexToBytes(nil, "99394F1D15924C0374CF80C7274CD9F232903A6423D9327156F69743EAEF03E1EFEDFDA8474C97F6570D9EF53C6CE2AE2BA68D01FFF9AA82068214BCD775B95CC297DDC38A63741AB3166B58275E0FB728D26DB18A2C3F14B621CF3863F8648B3149FE896348BE73D37E2F06E6E26C84C044984C09C658300B58EC2383E3B0A1F1390D62B772A69F37B5")
+
+var pssEncodedId = func(k int, data []byte) []byte {
+	return hexToBytes(nil, "3E641A22D0D0747D4ACC71884D3DFF2B2ADFDC1703B5A74EFD8333AB8C4377BB2A9B48E707F73409ABFBCD2DED69F52B16A145CE062FE6BD712C1952110DFB2316C5F3F321922ED375A4DEB8C41FA79BCAD86B0EA0D8FF02C9D0D5911BFF1E87DBCF073F71F18C08EB944AE84883A1E13FB1DEA123B5B1EFEA2A92635BD5D88F")
+}
+
+var randomISO = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
+	ys := make([]*bigmod.Nat, t)
+
+	rRaw := hexToBytes(nil, "487CDB0041BEED0323FDD3DEC8542584FA0E6CB990FAD5878DB34E9BEDDC95B65D22790C108E218407ED7F7D686657BAB5A28EF81C2E24985B56E37D9934E195A38A835CC02CEE8EBA2F56C87663E332976F5A3720DACA120BCD3DF0AEF6FD78582EBFCEE6D05E06172A871EAB0E8F5FC22DDB600F541B87CF8E147358374406")
+	r, err := bigmod.NewNat().SetBytes(rRaw, n)
+	if err != nil {
+		return nil, err
+	}
+
+	ys[0] = r
+	return ys, nil
+}
+
+// TODO:
+var sha1Hash = func(byteCount int, data ...[]byte) ([]byte, error) {
+	rng := sha1.New()
+	for _, d := range data {
+		rng.Write(d)
+	}
+	return rng.Sum(nil)[:byteCount], nil
+}
 
 func TestProveVerify(t *testing.T) {
 	oidcPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -49,46 +77,19 @@ func TestProveVerify(t *testing.T) {
 }
 
 func TestSignerISO(t *testing.T) {
-	useSha3 = false
-	defer func() {
-		useSha3 = true
-	}()
-
-	nBytes := hexToBytes(t, "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1")
-	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nBytes))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	nLen := n.BitLen()
-	vLen := vIso.BitLen() - 1
-	sv := signerVerifier{
-		n:      n,
-		v:      vIso,
-		t:      1,
-		nBytes: bytesForBits(nLen),
-		vBytes: bytesForBits(vLen),
-	}
-
-	Q := hexToBytes(t, "3BED38CEBB1219BC068774E0E2655CDEF67FE547BCF2D9FA9FE167B1E63B2F101A1483D38A8F24EDE365A3E44F4F10ADECEA7B30D042C14C162477B8184AE6CFAA78441B1FDFB0B223ABCD528B61F313D859FCF9C26FCAF9E4D9DA9BA83E9D2FDA041E8CCBF90056C31D654B546C1A7F6729A8DD8E68512F39E3B6F07959CE61")
+	h := hash
+	hash = sha1Hash
 
 	rn := randomNumbers
-	randomNumbers = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
-		ys := make([]*bigmod.Nat, t)
-
-		rRaw := hexToBytes(nil, "487CDB0041BEED0323FDD3DEC8542584FA0E6CB990FAD5878DB34E9BEDDC95B65D22790C108E218407ED7F7D686657BAB5A28EF81C2E24985B56E37D9934E195A38A835CC02CEE8EBA2F56C87663E332976F5A3720DACA120BCD3DF0AEF6FD78582EBFCEE6D05E06172A871EAB0E8F5FC22DDB600F541B87CF8E147358374406")
-		r, err := bigmod.NewNat().SetBytes(rRaw, n)
-		if err != nil {
-			return nil, err
-		}
-
-		ys[0] = r
-		return ys, nil
-	}
+	randomNumbers = randomISO
 
 	defer func() {
+		hash = h
 		randomNumbers = rn
 	}()
+
+	sv := signerVerifierISO(t)
+	Q := hexToBytes(t, "3BED38CEBB1219BC068774E0E2655CDEF67FE547BCF2D9FA9FE167B1E63B2F101A1483D38A8F24EDE365A3E44F4F10ADECEA7B30D042C14C162477B8184AE6CFAA78441B1FDFB0B223ABCD528B61F313D859FCF9C26FCAF9E4D9DA9BA83E9D2FDA041E8CCBF90056C31D654B546C1A7F6729A8DD8E68512F39E3B6F07959CE61")
 
 	encodedSig, err := sv.Sign(Q, messageIso)
 	if err != nil {
@@ -100,78 +101,26 @@ func TestSignerISO(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// TODO: I don't really need to separately check R and S
-
-	rHex := "99394F1D15924C0374CF"
-	R := make([]byte, hex.DecodedLen(len(rHex)))
-	_, err = hex.Decode(R, []byte(rHex))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < len(R); i++ {
-		if R[i] != sig[i] {
-			t.Fatal("Signature does not match expected value")
-		}
-	}
-
-	sHex := "80C7274CD9F232903A6423D9327156F69743EAEF03E1EFEDFDA8474C97F6570D9EF53C6CE2AE2BA68D01FFF9AA82068214BCD775B95CC297DDC38A63741AB3166B58275E0FB728D26DB18A2C3F14B621CF3863F8648B3149FE896348BE73D37E2F06E6E26C84C044984C09C658300B58EC2383E3B0A1F1390D62B772A69F37B5"
-	S := make([]byte, hex.DecodedLen(len(sHex)))
-	_, err = hex.Decode(S, []byte(sHex))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := len(R); i < len(sig); i++ {
-		j := i - len(R)
-		if S[j] != sig[i] {
-			t.Fatal("Signature does not match expected value")
-		}
+	if !bytes.Equal(sig, sigISO) {
+		t.Fatal("Signature does not match expected value")
 	}
 }
 
 func TestVerifierISO(t *testing.T) {
-	useSha3 = false
+	h := hash
+	hash = sha1Hash
+
+	e := encodePKCS1v15
+	encodePKCS1v15 = pssEncodedId
+
 	defer func() {
-		useSha3 = true
+		hash = h
+		encodePKCS1v15 = e
 	}()
 
-	nRaw := hexToBytes(t, "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1")
-	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nRaw))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	nLen := n.BitLen()
-	vLen := vIso.BitLen() - 1
-	sv := signerVerifier{
-		n:      n,
-		v:      vIso,
-		t:      1,
-		nBytes: bytesForBits(nLen),
-		vBytes: bytesForBits(vLen),
-	}
-
-	sigHex := "99394F1D15924C0374CF80C7274CD9F232903A6423D9327156F69743EAEF03E1EFEDFDA8474C97F6570D9EF53C6CE2AE2BA68D01FFF9AA82068214BCD775B95CC297DDC38A63741AB3166B58275E0FB728D26DB18A2C3F14B621CF3863F8648B3149FE896348BE73D37E2F06E6E26C84C044984C09C658300B58EC2383E3B0A1F1390D62B772A69F37B5"
-	sig := make([]byte, hex.DecodedLen(len(sigHex)))
-	_, err = hex.Decode(sig, []byte(sigHex))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	encodedSig := util.Base64EncodeForJWT(sig)
-
-	idHex := "416C657820416D706C65"
-	id := make([]byte, hex.DecodedLen(len(idHex)))
-	_, err = hex.Decode(id, []byte(idHex))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// TODO: need to replace this
-	encodePKCS1v15 = func(k int, data []byte) []byte {
-		return hexToBytes(nil, "3E641A22D0D0747D4ACC71884D3DFF2B2ADFDC1703B5A74EFD8333AB8C4377BB2A9B48E707F73409ABFBCD2DED69F52B16A145CE062FE6BD712C1952110DFB2316C5F3F321922ED375A4DEB8C41FA79BCAD86B0EA0D8FF02C9D0D5911BFF1E87DBCF073F71F18C08EB944AE84883A1E13FB1DEA123B5B1EFEA2A92635BD5D88F")
-	}
+	sv := signerVerifierISO(t)
+	encodedSig := util.Base64EncodeForJWT(sigISO)
+	id := hexToBytes(t, "416C657820416D706C65")
 
 	ok := sv.Verify(encodedSig, id, messageIso)
 
@@ -312,4 +261,23 @@ func hexToBytes(t *testing.T, hexStr string) []byte {
 	}
 
 	return bytes
+}
+
+// TODO:
+func signerVerifierISO(t *testing.T) signerVerifier {
+	nBytes := hexToBytes(t, "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1")
+	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nLen := n.BitLen()
+	vLen := vIso.BitLen() - 1
+	return signerVerifier{
+		n:      n,
+		v:      vIso,
+		t:      1,
+		nBytes: bytesForBits(nLen),
+		vBytes: bytesForBits(vLen),
+	}
 }

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -51,12 +51,7 @@ func TestSignerISO(t *testing.T) {
 		useSha3 = true
 	}()
 
-	nHex := "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1"
-	nRaw := make([]byte, hex.DecodedLen(len(nHex)))
-	_, err := hex.Decode(nRaw, []byte(nHex))
-	if err != nil {
-		t.Fatal(err)
-	}
+	nRaw := hexToBytes(t, "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1")
 	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nRaw))
 	if err != nil {
 		t.Fatal(err)
@@ -334,4 +329,14 @@ func createOIDCToken(oidcPrivKey *rsa.PrivateKey, audience string) ([]byte, erro
 	}
 
 	return jwt, nil
+}
+
+func hexToBytes(t *testing.T, hexStr string) []byte {
+	bytes := make([]byte, hex.DecodedLen(len(hexStr)))
+	_, err := hex.Decode(bytes, []byte(hexStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return bytes
 }

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -1,16 +1,19 @@
-package gq_test
+package gq
 
 import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
+	"filippo.io/bigmod"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jws"
-	"github.com/openpubkey/openpubkey/gq"
 	"github.com/openpubkey/openpubkey/util"
 )
 
@@ -27,7 +30,7 @@ func TestProveVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signerVerifier, err := gq.NewSignerVerifier(oidcPubKey, 256)
+	signerVerifier, err := NewSignerVerifier(oidcPubKey, 256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,6 +43,102 @@ func TestProveVerify(t *testing.T) {
 	ok := signerVerifier.VerifyJWT(gqToken)
 	if !ok {
 		t.Fatal("signature verification failed")
+	}
+}
+
+func TestISO(t *testing.T) {
+	useSha3 = false
+	defer func() {
+		useSha3 = true
+	}()
+
+	nHex := "D37B4534B4B788AE23E1E4719A395BBFF8A98EDBDCB3992306C513AAA95E9A335221998C20CD1344CA50C59193B84437FFC1E91E5EBEF9587615875102A7E83624DA4F72CAF28D1DF429652346D6F203E17C65288790F6F6D97835216B49F5932728A967D6D36561621FF38DFC185DFA5A160962E7C8E087CE90897B16EA4EA1"
+	nRaw := make([]byte, hex.DecodedLen(len(nHex)))
+	_, err := hex.Decode(nRaw, []byte(nHex))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := bigmod.NewModulusFromBig(new(big.Int).SetBytes(nRaw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vHex := "010000000000000000000D"
+	vRaw := make([]byte, hex.DecodedLen(len(vHex)))
+	_, err = hex.Decode(vRaw, []byte(vHex))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := new(big.Int).SetBytes([]byte(vRaw))
+
+	nLen := n.BitLen()
+	vLen := v.BitLen() - 1
+	sv := signerVerifier{
+		n:      n,
+		v:      v,
+		t:      1,
+		nBytes: bytesForBits(nLen),
+		vBytes: bytesForBits(vLen),
+	}
+
+	qHex := "3BED38CEBB1219BC068774E0E2655CDEF67FE547BCF2D9FA9FE167B1E63B2F101A1483D38A8F24EDE365A3E44F4F10ADECEA7B30D042C14C162477B8184AE6CFAA78441B1FDFB0B223ABCD528B61F313D859FCF9C26FCAF9E4D9DA9BA83E9D2FDA041E8CCBF90056C31D654B546C1A7F6729A8DD8E68512F39E3B6F07959CE61"
+	Q := make([]byte, hex.DecodedLen(len(qHex)))
+	_, err = hex.Decode(Q, []byte(qHex))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	message := []byte("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopqo")
+
+	randomNumbers = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
+		ys := make([]*bigmod.Nat, t)
+
+		rHex := "487CDB0041BEED0323FDD3DEC8542584FA0E6CB990FAD5878DB34E9BEDDC95B65D22790C108E218407ED7F7D686657BAB5A28EF81C2E24985B56E37D9934E195A38A835CC02CEE8EBA2F56C87663E332976F5A3720DACA120BCD3DF0AEF6FD78582EBFCEE6D05E06172A871EAB0E8F5FC22DDB600F541B87CF8E147358374406"
+		rRaw := make([]byte, hex.DecodedLen(len(rHex)))
+		hex.Decode(rRaw, []byte(rHex))
+		r, _ := bigmod.NewNat().SetBytes(rRaw, n)
+
+		ys[0] = r
+		return ys, nil
+	}
+
+	encodedSig, err := sv.Sign(Q, message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := util.Base64DecodeForJWT(encodedSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rHex := "99394F1D15924C0374CF"
+	R := make([]byte, hex.DecodedLen(len(rHex)))
+	_, err = hex.Decode(R, []byte(rHex))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("hex.EncodeToString(sig): %v\n", hex.EncodeToString(sig))
+
+	for i := 0; i < len(R); i++ {
+		if R[i] != sig[i] {
+			t.Fatal("Signature does not match expected value")
+		}
+	}
+
+	sHex := "80C7274CD9F232903A6423D9327156F69743EAEF03E1EFEDFDA8474C97F6570D9EF53C6CE2AE2BA68D01FFF9AA82068214BCD775B95CC297DDC38A63741AB3166B58275E0FB728D26DB18A2C3F14B621CF3863F8648B3149FE896348BE73D37E2F06E6E26C84C044984C09C658300B58EC2383E3B0A1F1390D62B772A69F37B5"
+	S := make([]byte, hex.DecodedLen(len(sHex)))
+	_, err = hex.Decode(S, []byte(sHex))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := len(R); i < len(sig); i++ {
+		j := i - len(R)
+		if S[j] != sig[i] {
+			t.Fatal("Signature does not match expected value")
+		}
 	}
 }
 
@@ -65,7 +164,7 @@ func TestVerifyModifiedIdPayload(t *testing.T) {
 	if err == nil {
 		t.Fatal("ID token signature should fail for modified token")
 	}
-	signerVerifier, err := gq.NewSignerVerifier(oidcPubKey, 256)
+	signerVerifier, err := NewSignerVerifier(oidcPubKey, 256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +192,7 @@ func TestVerifyModifiedGqPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signerVerifier, err := gq.NewSignerVerifier(oidcPubKey, 256)
+	signerVerifier, err := NewSignerVerifier(oidcPubKey, 256)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gq/rsa.go
+++ b/gq/rsa.go
@@ -2,10 +2,7 @@ package gq
 
 import (
 	"crypto"
-	"crypto/sha1"
 	"crypto/sha256"
-	"fmt"
-	"hash"
 )
 
 // Hardcoded padding prefix for SHA-256 from https://github.com/golang/go/blob/eca5a97340e6b475268a522012f30e8e25bb8b8f/src/crypto/rsa/pkcs1v15.go#L268
@@ -14,7 +11,7 @@ var prefix = []byte{0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 
 // encodePKCS1v15 is taken from the go stdlib, see [crypto/rsa.SignPKCS1v15].
 //
 // https://github.com/golang/go/blob/eca5a97340e6b475268a522012f30e8e25bb8b8f/src/crypto/rsa/pkcs1v15.go#L287-L317
-func encodePKCS1v15(k int, data []byte) []byte {
+var encodePKCS1v15 = func(k int, data []byte) []byte {
 	hashLen := crypto.SHA256.Size()
 	tLen := len(prefix) + hashLen
 
@@ -29,116 +26,4 @@ func encodePKCS1v15(k int, data []byte) []byte {
 	hashed := sha256.Sum256(data)
 	copy(em[k-hashLen:k], hashed[:])
 	return em
-}
-
-// func emsaPSSEncode(mHash []byte, emBits int, salt []byte, hash hash.Hash) ([]byte, error) {
-func encodePSS(emBits int, data []byte) []byte {
-	// See RFC 8017, Section 9.1.1.
-
-	hLen := crypto.SHA1.Size()
-	salt := []byte("")
-	sLen := 0
-	emLen := (emBits + 7) / 8
-
-	// 1.  If the length of M is greater than the input limitation for the
-	//     hash function (2^61 - 1 octets for SHA-1), output "message too
-	//     long" and stop.
-	//
-	// 2.  Let mHash = Hash(M), an octet string of length hLen.
-
-	if len(data) != hLen {
-		fmt.Println("Oh no 1")
-		return nil
-	}
-
-	// 3.  If emLen < hLen + sLen + 2, output "encoding error" and stop.
-
-	if emLen < hLen+sLen+2 {
-		fmt.Println("Oh no 2")
-		return nil
-	}
-
-	em := make([]byte, emLen)
-	psLen := emLen - sLen - hLen - 2
-	db := em[:psLen+1+sLen]
-	h := em[psLen+1+sLen : emLen-1]
-
-	// 4.  Generate a random octet string salt of length sLen; if sLen = 0,
-	//     then salt is the empty string.
-	//
-	// 5.  Let
-	//       M' = (0x)00 00 00 00 00 00 00 00 || mHash || salt;
-	//
-	//     M' is an octet string of length 8 + hLen + sLen with eight
-	//     initial zero octets.
-	//
-	// 6.  Let H = Hash(M'), an octet string of length hLen.
-
-	var prefix [8]byte
-
-	hashFn := sha1.New()
-	hashFn.Write(prefix[:])
-	hashFn.Write(data)
-	hashFn.Write(salt)
-
-	h = hashFn.Sum(h[:0])
-	hashFn.Reset()
-
-	// 7.  Generate an octet string PS consisting of emLen - sLen - hLen - 2
-	//     zero octets. The length of PS may be 0.
-	//
-	// 8.  Let DB = PS || 0x01 || salt; DB is an octet string of length
-	//     emLen - hLen - 1.
-
-	db[psLen] = 0x01
-	copy(db[psLen+1:], salt)
-
-	// 9.  Let dbMask = MGF(H, emLen - hLen - 1).
-	//
-	// 10. Let maskedDB = DB \xor dbMask.
-
-	mgf1XOR(db, hashFn, h)
-
-	// 11. Set the leftmost 8 * emLen - emBits bits of the leftmost octet in
-	//     maskedDB to zero.
-
-	db[0] &= 0xff >> (8*emLen - emBits)
-
-	// 12. Let EM = maskedDB || H || 0xbc.
-	em[emLen-1] = 0xbc
-
-	// 13. Output EM.
-	return em
-}
-
-func mgf1XOR(out []byte, hash hash.Hash, seed []byte) {
-	var counter [4]byte
-	var digest []byte
-
-	done := 0
-	for done < len(out) {
-		hash.Write(seed)
-		hash.Write(counter[0:4])
-		digest = hash.Sum(digest[:0])
-		hash.Reset()
-
-		for i := 0; i < len(digest) && done < len(out); i++ {
-			out[done] ^= digest[i]
-			done++
-		}
-		incCounter(&counter)
-	}
-}
-
-func incCounter(c *[4]byte) {
-	if c[3]++; c[3] != 0 {
-		return
-	}
-	if c[2]++; c[2] != 0 {
-		return
-	}
-	if c[1]++; c[1] != 0 {
-		return
-	}
-	c[0]++
 }

--- a/gq/rsa.go
+++ b/gq/rsa.go
@@ -2,7 +2,10 @@ package gq
 
 import (
 	"crypto"
+	"crypto/sha1"
 	"crypto/sha256"
+	"fmt"
+	"hash"
 )
 
 // Hardcoded padding prefix for SHA-256 from https://github.com/golang/go/blob/eca5a97340e6b475268a522012f30e8e25bb8b8f/src/crypto/rsa/pkcs1v15.go#L268
@@ -26,4 +29,116 @@ func encodePKCS1v15(k int, data []byte) []byte {
 	hashed := sha256.Sum256(data)
 	copy(em[k-hashLen:k], hashed[:])
 	return em
+}
+
+// func emsaPSSEncode(mHash []byte, emBits int, salt []byte, hash hash.Hash) ([]byte, error) {
+func encodePSS(emBits int, data []byte) []byte {
+	// See RFC 8017, Section 9.1.1.
+
+	hLen := crypto.SHA1.Size()
+	salt := []byte("")
+	sLen := 0
+	emLen := (emBits + 7) / 8
+
+	// 1.  If the length of M is greater than the input limitation for the
+	//     hash function (2^61 - 1 octets for SHA-1), output "message too
+	//     long" and stop.
+	//
+	// 2.  Let mHash = Hash(M), an octet string of length hLen.
+
+	if len(data) != hLen {
+		fmt.Println("Oh no 1")
+		return nil
+	}
+
+	// 3.  If emLen < hLen + sLen + 2, output "encoding error" and stop.
+
+	if emLen < hLen+sLen+2 {
+		fmt.Println("Oh no 2")
+		return nil
+	}
+
+	em := make([]byte, emLen)
+	psLen := emLen - sLen - hLen - 2
+	db := em[:psLen+1+sLen]
+	h := em[psLen+1+sLen : emLen-1]
+
+	// 4.  Generate a random octet string salt of length sLen; if sLen = 0,
+	//     then salt is the empty string.
+	//
+	// 5.  Let
+	//       M' = (0x)00 00 00 00 00 00 00 00 || mHash || salt;
+	//
+	//     M' is an octet string of length 8 + hLen + sLen with eight
+	//     initial zero octets.
+	//
+	// 6.  Let H = Hash(M'), an octet string of length hLen.
+
+	var prefix [8]byte
+
+	hashFn := sha1.New()
+	hashFn.Write(prefix[:])
+	hashFn.Write(data)
+	hashFn.Write(salt)
+
+	h = hashFn.Sum(h[:0])
+	hashFn.Reset()
+
+	// 7.  Generate an octet string PS consisting of emLen - sLen - hLen - 2
+	//     zero octets. The length of PS may be 0.
+	//
+	// 8.  Let DB = PS || 0x01 || salt; DB is an octet string of length
+	//     emLen - hLen - 1.
+
+	db[psLen] = 0x01
+	copy(db[psLen+1:], salt)
+
+	// 9.  Let dbMask = MGF(H, emLen - hLen - 1).
+	//
+	// 10. Let maskedDB = DB \xor dbMask.
+
+	mgf1XOR(db, hashFn, h)
+
+	// 11. Set the leftmost 8 * emLen - emBits bits of the leftmost octet in
+	//     maskedDB to zero.
+
+	db[0] &= 0xff >> (8*emLen - emBits)
+
+	// 12. Let EM = maskedDB || H || 0xbc.
+	em[emLen-1] = 0xbc
+
+	// 13. Output EM.
+	return em
+}
+
+func mgf1XOR(out []byte, hash hash.Hash, seed []byte) {
+	var counter [4]byte
+	var digest []byte
+
+	done := 0
+	for done < len(out) {
+		hash.Write(seed)
+		hash.Write(counter[0:4])
+		digest = hash.Sum(digest[:0])
+		hash.Reset()
+
+		for i := 0; i < len(digest) && done < len(out); i++ {
+			out[done] ^= digest[i]
+			done++
+		}
+		incCounter(&counter)
+	}
+}
+
+func incCounter(c *[4]byte) {
+	if c[3]++; c[3] != 0 {
+		return
+	}
+	if c[2]++; c[2] != 0 {
+		return
+	}
+	if c[1]++; c[1] != 0 {
+		return
+	}
+	c[0]++
 }

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -2,6 +2,8 @@ package gq
 
 import (
 	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"math/big"
 
 	"filippo.io/bigmod"
@@ -41,7 +43,7 @@ func (sv *signerVerifier) Sign(private []byte, message []byte) ([]byte, error) {
 
 	// Stage 3 - calculate question number R
 	// hash W and M and take first t*vBytes bytes as R
-	R, err := hash(t*vBytes, W, M)
+	R, err := gqHash(t*vBytes, W, M)
 	if err != nil {
 		return nil, err
 	}
@@ -179,13 +181,15 @@ func (sv *signerVerifier) modInverse(b *memguard.LockedBuffer) (*memguard.Locked
 func encodeProof(R, S []byte) []byte {
 	var bin []byte
 
+	fmt.Printf("hex.EncodeToString(R): %v\n", hex.EncodeToString(R))
+
 	bin = append(bin, R...)
 	bin = append(bin, S...)
 
 	return util.Base64EncodeForJWT(bin)
 }
 
-func randomNumbers(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
+var randomNumbers = func(t int, n *bigmod.Modulus) ([]*bigmod.Nat, error) {
 	nInt := modAsInt(n)
 	ys := make([]*bigmod.Nat, t)
 

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -2,8 +2,6 @@ package gq
 
 import (
 	"crypto/rand"
-	"encoding/hex"
-	"fmt"
 	"math/big"
 
 	"filippo.io/bigmod"
@@ -43,7 +41,7 @@ func (sv *signerVerifier) Sign(private []byte, message []byte) ([]byte, error) {
 
 	// Stage 3 - calculate question number R
 	// hash W and M and take first t*vBytes bytes as R
-	R, err := gqHash(t*vBytes, W, M)
+	R, err := hash(t*vBytes, W, M)
 	if err != nil {
 		return nil, err
 	}
@@ -180,8 +178,6 @@ func (sv *signerVerifier) modInverse(b *memguard.LockedBuffer) (*memguard.Locked
 
 func encodeProof(R, S []byte) []byte {
 	var bin []byte
-
-	fmt.Printf("hex.EncodeToString(R): %v\n", hex.EncodeToString(R))
 
 	bin = append(bin, R...)
 	bin = append(bin, S...)

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -25,13 +25,7 @@ func (sv *signerVerifier) Verify(proof []byte, identity []byte, message []byte) 
 
 	// Stage 1 - create public number G
 	// currently this hardcoded to use PKCS#1 v1.5 padding as the format mechanism
-	// FIXME:
-	var paddedIdentity []byte
-	if useSha3 {
-		paddedIdentity = encodePKCS1v15(nBytes, identity)
-	} else {
-		paddedIdentity = encodePSS(nBytes, identity)
-	}
+	paddedIdentity := encodePKCS1v15(nBytes, identity)
 	G := new(big.Int).SetBytes(paddedIdentity)
 
 	// Stage 2 - parse signature numbers and recalculate test number W*
@@ -68,7 +62,7 @@ func (sv *signerVerifier) Verify(proof []byte, identity []byte, message []byte) 
 
 	// Stage 3 - recalculate question number R*
 	// hash W* and M and take first t*vBytes bytes as R*
-	Rstar, err := gqHash(t*vBytes, Wstar, M)
+	Rstar, err := hash(t*vBytes, Wstar, M)
 	if err != nil {
 		// TODO: this can only happen if there's some error reading /dev/urandom or something
 		// so should we return the proper error?

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -25,7 +25,13 @@ func (sv *signerVerifier) Verify(proof []byte, identity []byte, message []byte) 
 
 	// Stage 1 - create public number G
 	// currently this hardcoded to use PKCS#1 v1.5 padding as the format mechanism
-	paddedIdentity := encodePKCS1v15(nBytes, identity)
+	// FIXME:
+	var paddedIdentity []byte
+	if useSha3 {
+		paddedIdentity = encodePKCS1v15(nBytes, identity)
+	} else {
+		paddedIdentity = encodePSS(nBytes, identity)
+	}
 	G := new(big.Int).SetBytes(paddedIdentity)
 
 	// Stage 2 - parse signature numbers and recalculate test number W*
@@ -62,7 +68,7 @@ func (sv *signerVerifier) Verify(proof []byte, identity []byte, message []byte) 
 
 	// Stage 3 - recalculate question number R*
 	// hash W* and M and take first t*vBytes bytes as R*
-	Rstar, err := hash(t*vBytes, Wstar, M)
+	Rstar, err := gqHash(t*vBytes, Wstar, M)
 	if err != nil {
 		// TODO: this can only happen if there's some error reading /dev/urandom or something
 		// so should we return the proper error?


### PR DESCRIPTION
Closes #69 

Adds specific signer/verifier tests against the values laid out in the ISO standard on which our implementation is based.

There is one painful difference between the standard and our implementation. It uses SHA-1 instead of SHAKE-256 as a hash function and uses PSS instead of PKCS15 as an encoding / format mechanism. I considered making our solution fully plug-and-play with regard to these functions. However, this incurs a huge code complexity expense because the functions in question do not share the same interface in the go standard library. Instead, I opted to turn the relevant functions into `vars` and rewire them at test time. This requires moving the tests from a dedicated `gq_test` package to the `gq` package.

The above is all somewhat messy and I am open to discussing alternatives. However, I believe it is the cleanest way of achieving this test coverage. The good news is that **our implementation was correct on the first attempt with no modifications needed**. 