### PR TITLE
Add support for external Op public key resolution

### DIFF
--- a/client/oidc.go
+++ b/client/oidc.go
@@ -48,7 +48,6 @@ func VerifyPKToken(ctx context.Context, pkt *pktoken.PKToken, provider OpenIdPro
 
 	switch sigType {
 	case pktoken.Gq:
-		// TODO: this needs to get the public key from a log of historic public keys based on the iat time in the token
 		pubKey, err := provider.PublicKey(ctx, idt)
 		if err != nil {
 			return fmt.Errorf("failed to get OP public key: %w", err)

--- a/client/providers/public.go
+++ b/client/providers/public.go
@@ -1,0 +1,30 @@
+package providers
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+
+	"github.com/openpubkey/openpubkey/client"
+)
+
+type PublicKeyResolver func(context.Context, []byte) (crypto.PublicKey, error)
+
+type publicKeyResolver struct {
+	client.OpenIdProvider
+	resolver PublicKeyResolver
+}
+
+func WithPublicKeyResolver(provider client.OpenIdProvider, resolver PublicKeyResolver) client.OpenIdProvider {
+	return &publicKeyResolver{
+		OpenIdProvider: provider,
+		resolver:       resolver,
+	}
+}
+
+func (e *publicKeyResolver) PublicKey(ctx context.Context, idt []byte) (crypto.PublicKey, error) {
+	if e.resolver == nil {
+		return nil, fmt.Errorf("resolver is nil")
+	}
+	return e.resolver(ctx, idt)
+}

--- a/client/providers/public_test.go
+++ b/client/providers/public_test.go
@@ -1,0 +1,36 @@
+package providers
+
+import (
+	"context"
+	"crypto"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/openpubkey/openpubkey/util"
+)
+
+func TestPublicKeyResolver(t *testing.T) {
+	provider, _ := NewMockOpenIdProvider()
+	alg := jwa.RS256
+	signingKey, err := util.GenKeyPair(alg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := func(ctx context.Context, idt []byte) (crypto.PublicKey, error) {
+		return signingKey.Public(), nil
+	}
+	wrapped := WithPublicKeyResolver(provider, nil)
+	_, e := wrapped.PublicKey(context.Background(), []byte{})
+	if e == nil {
+		t.Fatal("Expected error")
+	}
+	wrapped = WithPublicKeyResolver(provider, resolver)
+	p, _ := wrapped.PublicKey(context.Background(), []byte{})
+	if p != signingKey.Public() {
+		t.Fatal("Unexpected public key")
+	}
+	s, _ := provider.PublicKey(context.Background(), []byte{})
+	if p == s {
+		t.Fatal("Unexpected public key")
+	}
+}


### PR DESCRIPTION
To be able to verify signatures once Op public keys have rotated, it's necessary for the verifier to consult a log.

This PR adds a wrapper/decorator so that public key resolution can be delegated to a custom function.

It might make more sense to make breaking changes to the provider APIs rather than wrapping like this given we are not at 1.0 yet though.