### PR TITLE
Creates OpkClient constructor and moves singer/alg/gqflag into the OpkClient struct

### DIFF
--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -42,7 +42,7 @@ func TestCreateX509Cert(t *testing.T) {
 	opkClient, err := client.New(op, client.WithSigner(signer, alg), client.WithSignGQ(true))
 	require.NoError(t, err)
 
-	pkToken, err := opkClient.Auth(context.Background(), client.WithExtraClaims(map[string]any{}))
+	pkToken, err := opkClient.Auth(context.Background())
 	require.NoError(t, err)
 
 	// create x509 cert from pk token

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package cert
 
 import (
@@ -11,61 +27,49 @@ import (
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/client/providers"
 	"github.com/openpubkey/openpubkey/util"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateX509Cert(t *testing.T) {
+	alg := jwa.ES256
 	// generate pktoken
-	signer, err := util.GenKeyPair(jwa.ES256)
-	if err != nil {
-		t.Fatal(err)
-	}
-	provider, err := providers.NewMockOpenIdProvider()
-	if err != nil {
-		t.Fatal(err)
-	}
-	opkClient := client.OpkClient{Op: provider}
-	pkToken, err := opkClient.OidcAuth(context.Background(), signer, jwa.ES256, map[string]any{}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	signer, err := util.GenKeyPair(alg)
+	require.NoError(t, err)
+
+	op, err := providers.NewMockOpenIdProvider()
+	require.NoError(t, err)
+
+	opkClient, err := client.New(op, client.WithSigner(signer, alg), client.WithSignGQ(true))
+	require.NoError(t, err)
+
+	pkToken, err := opkClient.Auth(context.Background(), client.WithExtraClaims(map[string]any{}))
+	require.NoError(t, err)
 
 	// create x509 cert from pk token
 	cert, err := CreateX509Cert(pkToken, signer)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	p, _ := pem.Decode(cert)
 	result, err := x509.ParseCertificate(p.Bytes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// test cert SubjectKeyId field contains PK token
 	pkTokenJSON, err := json.Marshal(pkToken)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(result.SubjectKeyId) != string(pkTokenJSON) {
-		t.Fatal("certificate subject key id does not match PK token")
-	}
+	require.NoError(t, err)
+	require.Equal(t, string(pkTokenJSON), string(result.SubjectKeyId),
+		"certificate subject key id does not match PK token")
 
 	// test cert RawSubjectPublicKeyInfo field contains ephemeral public key
 	ecPub, err := x509.MarshalPKIXPublicKey(signer.Public())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(result.RawSubjectPublicKeyInfo) != string(ecPub) {
-		t.Fatal("certificate raw subject public key info does not match ephemeral public key")
-	}
+	require.NoError(t, err)
+	require.Equal(t, string(ecPub), string(result.RawSubjectPublicKeyInfo),
+		"certificate raw subject public key info does not match ephemeral public key")
 
 	// test cert common name == pktoken sub claim
 	var payload struct {
 		Subject string `json:"sub"`
 	}
-	if err := json.Unmarshal(pkToken.Payload, &payload); err != nil {
-		t.Fatal(err)
-	}
-	if result.Subject.CommonName != payload.Subject {
-		t.Fatal("cert common name does not equal pk token sub claim")
-	}
+	err = json.Unmarshal(pkToken.Payload, &payload)
+	require.NoError(t, err)
+	require.Equal(t, payload.Subject, result.Subject.CommonName, "cert common name does not equal pk token sub claim")
 }

--- a/client/client.go
+++ b/client/client.go
@@ -92,7 +92,7 @@ func New(op OpenIdProvider, opts ...ClientOpts) (*OpkClient, error) {
 	}
 
 	if client.alg == nil && client.signer != nil {
-		return nil, fmt.Errorf("signer specified but alg is nil, must specify alg  of signer")
+		return nil, fmt.Errorf("signer specified but alg is nil, must specify alg of signer")
 	}
 
 	if client.signer == nil {

--- a/client/client.go
+++ b/client/client.go
@@ -60,8 +60,8 @@ func WithSigner(signer crypto.Signer, alg jwa.KeyAlgorithm) ClientOpts {
 	}
 }
 
-// WithSignGQ specifies if the client should replace the ID Token's signature
-// with a GQ Signature.
+// WithSignGQ specifies if the OPs signature on the ID Token should be replaced
+// with a GQ signature by the client.
 func WithSignGQ(signGQ bool) ClientOpts {
 	return func(o *OpkClient) {
 		o.signGQ = signGQ
@@ -137,9 +137,6 @@ func WithExtraClaims(extraClaims map[string]any) AuthOpts {
 // authenticate to the configured OpenID Provider (OP) and receive an ID Token.
 // Using this ID Token it will generate a PK Token. If a Cosigner has been
 // configured it will also attempt to get the PK Token cosigned.
-//
-// signGQ specifies if the OPs signature on the ID Token should be replaced
-// with a GQ signature.
 func (o *OpkClient) Auth(ctx context.Context, opts ...AuthOpts) (*pktoken.PKToken, error) {
 	authOpts := &AuthOptsStruct{
 		extraClaims: map[string]any{},

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ import (
 
 type OpkClient struct {
 	Op     OpenIdProvider
-	CosP   *CosignerProvider
+	cosP   *CosignerProvider
 	signer crypto.Signer
 	alg    jwa.KeyAlgorithm
 	signGQ bool // Default is false
@@ -73,7 +73,7 @@ func WithSignGQ(signGQ bool) ClientOpts {
 // is skipped.
 func WithCosignerProvider(cosP *CosignerProvider) ClientOpts {
 	return func(o *OpkClient) {
-		o.CosP = cosP
+		o.cosP = cosP
 	}
 }
 
@@ -146,7 +146,7 @@ func (o *OpkClient) Auth(ctx context.Context, opts ...AuthOpts) (*pktoken.PKToke
 	}
 
 	// If no Cosigner is set then do standard OIDC authentication
-	if o.CosP == nil {
+	if o.cosP == nil {
 		return o.OidcAuth(ctx, o.signer, o.alg, authOpts.extraClaims, o.signGQ)
 	}
 
@@ -165,7 +165,7 @@ func (o *OpkClient) Auth(ctx context.Context, opts ...AuthOpts) (*pktoken.PKToke
 		if err != nil {
 			return nil, err
 		}
-		return o.CosP.RequestToken(ctx, o.signer, pkt, redirCh)
+		return o.cosP.RequestToken(ctx, o.signer, pkt, redirCh)
 	}
 }
 
@@ -258,6 +258,14 @@ func (o *OpkClient) OidcAuth(
 		return nil, fmt.Errorf("error adding JKT header: %w", err)
 	}
 	return pkt, nil
+}
+
+func (o *OpkClient) GetOp() OpenIdProvider {
+	return o.Op
+}
+
+func (o *OpkClient) GetCosP() *CosignerProvider {
+	return o.cosP
 }
 
 func (o *OpkClient) GetSigner() crypto.Signer {

--- a/client/client.go
+++ b/client/client.go
@@ -96,7 +96,7 @@ func New(op OpenIdProvider, opts ...ClientOpts) (*OpkClient, error) {
 	}
 
 	if client.signer == nil {
-		// Generate signer for specified alg, if no alg specified choose ES256
+		// Generate signer for specified alg. If no alg specified, defaults to ES256
 		if client.alg == nil {
 			client.alg = jwa.ES256
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -116,20 +116,19 @@ type AuthOptsStruct struct {
 }
 type AuthOpts func(a *AuthOptsStruct)
 
-// WithExtraClaims specifies additional values to be included in the
+// WithExtraClaim specifies additional values to be included in the
 // CIC. These claims will be include in the CIC protected header and
 // will be hashed into the commitment claim in the ID Token. The
 // commitment claim is typically the nonce or aud claim in the ID Token.
 // Example use:
 //
-//	WithExtraClaims(map[string]any{"claimKey": "claimValuez"})
-func WithExtraClaims(extraClaims map[string]any) AuthOpts {
+//	WithExtraClaim("claimKey", "claimValue")
+func WithExtraClaim(k string, v string) AuthOpts {
 	return func(a *AuthOptsStruct) {
-		// Replace with maps.Clone when Clone is no longer experimental
-		a.extraClaims = map[string]any{}
-		for k, v := range extraClaims {
-			a.extraClaims[k] = v
+		if a.extraClaims == nil {
+			a.extraClaims = map[string]any{}
 		}
+		a.extraClaims[k] = v
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -77,6 +77,8 @@ func WithCosignerProvider(cosP *CosignerProvider) ClientOpts {
 	}
 }
 
+// New returns a new client.OpkClient. The op argument should be the
+// OpenID Provider you want to authenticate against.
 func New(op OpenIdProvider, opts ...ClientOpts) (*OpkClient, error) {
 	client := &OpkClient{
 		Op:     op,

--- a/client/client.go
+++ b/client/client.go
@@ -119,7 +119,7 @@ type AuthOpts func(a *AuthOptsStruct)
 // WithExtraClaims specifies additional values to be included in the
 // CIC. These claims will be include in the CIC protected header and
 // will be hashed into the commitment claim in the ID Token. The
-// commitment claim is typically the nonce or aud claim in the ID Token).
+// commitment claim is typically the nonce or aud claim in the ID Token.
 // Example use:
 //
 //	WithExtraClaims(map[string]any{"claimKey": "claimValuez"})

--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package client_test
 
 import (
@@ -12,34 +28,67 @@ import (
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/client/providers"
 	"github.com/openpubkey/openpubkey/gq"
+	"github.com/openpubkey/openpubkey/pktoken"
 	"github.com/openpubkey/openpubkey/util"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClient(t *testing.T) {
 	testCases := []struct {
-		name string
-		gq   bool
+		name        string
+		gq          bool
+		signer      bool
+		alg         jwa.KeyAlgorithm
+		extraClaims map[string]any
 	}{
-		{name: "without GQ", gq: false},
-		{name: "with GQ", gq: true},
+		{name: "without GQ", gq: false, signer: false},
+		{name: "with GQ", gq: true, signer: false},
+		{name: "with GQ, with signer", gq: true, signer: true, alg: jwa.RS256},
+		{name: "with GQ, with signer, with empty extraClaims ", gq: true, signer: true, alg: jwa.ES256, extraClaims: map[string]any{}},
+		{name: "with GQ, with signer, with extraClaims", gq: true, signer: true, alg: jwa.ES256, extraClaims: map[string]any{"extra": "yes"}},
+		{name: "with GQ, with extraClaims", gq: true, signer: false, extraClaims: map[string]any{"extra": "yes", "aaa": "bbb"}},
 	}
 
 	op, err := providers.NewMockOpenIdProvider()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "failed to create mock OpenIdProvider")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := client.OpkClient{
-				Op:     op,
-				SignGQ: tc.gq,
+
+			var c *client.OpkClient
+			if tc.signer {
+				signer, err := util.GenKeyPair(tc.alg)
+				require.NoError(t, err, tc.name)
+				c, err = client.New(op, client.WithSignGQ(tc.gq), client.WithSigner(signer, tc.alg))
+				require.NoError(t, err, tc.name)
+				require.Equal(t, signer, c.GetSigner(), tc.name)
+				require.Equal(t, tc.alg, c.GetAlg(), tc.name)
+			} else if tc.gq {
+				c, err = client.New(op, client.WithSignGQ(tc.gq))
+				require.NoError(t, err, tc.name)
+			} else {
+				c, err = client.New(op)
+				require.NoError(t, err, tc.name)
+			}
+			require.Equal(t, tc.gq, c.GetSignGQ(), tc.name)
+
+			var pkt *pktoken.PKToken
+
+			if tc.extraClaims != nil {
+				pkt, err = c.Auth(context.Background(), client.WithExtraClaims(tc.extraClaims))
+				require.NoError(t, err, tc.name)
+				cicPH, err := pkt.Cic.ProtectedHeaders().AsMap(context.TODO())
+				require.NoError(t, err, tc.name)
+
+				// ensure the extra claims we set are in the PK Token
+				for k, v := range tc.extraClaims {
+					require.Equal(t, v, cicPH[k], tc.name)
+				}
+			} else {
+				pkt, err = c.Auth(context.Background())
+				require.NoError(t, err, tc.name)
 			}
 
-			pkt, err := c.Auth(context.Background())
-			if err != nil {
-				t.Fatal(err)
-			}
 			jkt, ok := pkt.Op.PublicHeaders().Get("jkt")
 			if !ok {
 				t.Fatal("missing jkt header")
@@ -51,21 +100,16 @@ func TestClient(t *testing.T) {
 			jktstr := string(data)
 
 			pubkey, err := op.PublicKey(context.Background(), nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err, tc.name)
+
 			pub, err := jwk.FromRaw(pubkey)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err, tc.name)
+
 			thumbprint, err := pub.Thumbprint(crypto.SHA256)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err, tc.name)
+
 			thumbprintStr := string(util.Base64EncodeForJWT(thumbprint))
-			if jktstr != thumbprintStr {
-				t.Errorf("jkt header %s does not match op thumbprint %s", jkt, thumbprintStr)
-			}
+			require.Equal(t, jktstr, thumbprintStr, "jkt header does not match op thumbprint in "+tc.name)
 
 			alg, ok := pkt.ProviderAlgorithm()
 			if !ok {
@@ -73,33 +117,25 @@ func TestClient(t *testing.T) {
 			}
 
 			if tc.gq {
-				if alg != gq.GQ256 {
-					t.Errorf("expected GQ256 alg when signing with GQ, got %s", alg)
-				}
+				require.Equal(t, gq.GQ256, alg, tc.name)
 
 				// Verify our GQ signature
 				idt, err := pkt.Compact(pkt.Op)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err, tc.name)
 
 				opPubKey, err := op.PublicKey(context.Background(), nil)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err, tc.name)
 
 				sv, err := gq.NewSignerVerifier(opPubKey.(*rsa.PublicKey), client.GQSecurityParameter)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err, tc.name)
+
 				ok := sv.VerifyJWT(idt)
 				if !ok {
 					t.Fatal(fmt.Errorf("error verifying OP GQ signature on PK Token (ID Token invalid)"))
 				}
 			} else {
-				if alg != jwa.RS256 {
-					t.Errorf("expected RS256 alg when not signing with GQ, got %s", alg)
-				}
+				// Expect alg to be RS256 alg when not signing with GQ
+				require.Equal(t, jwa.RS256, alg, tc.name)
 			}
 		})
 	}

--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	alg := jwa.ES256
-
 	testCases := []struct {
 		name string
 		gq   bool
@@ -33,16 +31,12 @@ func TestClient(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			signer, err := util.GenKeyPair(alg)
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			c := client.OpkClient{
-				Op: op,
+				Op:     op,
+				SignGQ: tc.gq,
 			}
 
-			pkt, err := c.OidcAuth(context.Background(), signer, alg, map[string]any{}, tc.gq)
+			pkt, err := c.Auth(context.Background())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -105,7 +105,7 @@ func login(outputDir string, signGQ bool) error {
 	}
 
 	pkt, err := opkClient.Auth(context.Background(),
-		client.WithExtraClaims(map[string]any{"extra": "yes"}))
+		client.WithExtraClaim("extra", "yes"))
 	if err != nil {
 		return err
 	}

--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -30,7 +30,6 @@ import (
 	"path"
 
 	"github.com/awnumar/memguard"
-	"github.com/lestrrat-go/jwx/v2/jwa"
 
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/client/providers"
@@ -67,7 +66,6 @@ func main() {
 	}
 
 	signGQ := true
-	keyAlgorithm := jwa.ES256
 
 	// Directory for saving data
 	outputDir := "output/google"
@@ -75,14 +73,14 @@ func main() {
 	command := os.Args[1]
 	switch command {
 	case "login":
-		if err := login(outputDir, keyAlgorithm, signGQ); err != nil {
+		if err := login(outputDir, signGQ); err != nil {
 			fmt.Println("Error logging in:", err)
 		} else {
 			fmt.Println("Login successful!")
 		}
 	case "sign":
 		message := "sign me!!"
-		if err := sign(message, outputDir, keyAlgorithm, signGQ); err != nil {
+		if err := sign(message, outputDir, signGQ); err != nil {
 			fmt.Println("Failed to sign test message:", err)
 		}
 	default:
@@ -90,11 +88,7 @@ func main() {
 	}
 }
 
-func login(outputDir string, alg jwa.KeyAlgorithm, signGQ bool) error {
-	signer, err := util.GenKeyPair(alg)
-	if err != nil {
-		return err
-	}
+func login(outputDir string, signGQ bool) error {
 
 	client := &client.OpkClient{
 		Op: &providers.GoogleOp{
@@ -105,9 +99,11 @@ func login(outputDir string, alg jwa.KeyAlgorithm, signGQ bool) error {
 			CallbackPath: callbackPath,
 			RedirectURI:  redirectURI,
 		},
+		SignGQ:      signGQ,
+		ExtraClaims: map[string]any{"extra": "yes"},
 	}
 
-	pkt, err := client.Auth(context.Background(), signer, alg, map[string]any{"extra": "yes"}, signGQ)
+	pkt, err := client.Auth(context.Background())
 	if err != nil {
 		return err
 	}
@@ -120,10 +116,10 @@ func login(outputDir string, alg jwa.KeyAlgorithm, signGQ bool) error {
 	fmt.Println(string(pktJson))
 
 	// Save our signer and pktoken by writing them to a file
-	return saveLogin(outputDir, signer.(*ecdsa.PrivateKey), pkt)
+	return saveLogin(outputDir, client.Signer.(*ecdsa.PrivateKey), pkt)
 }
 
-func sign(message string, outputDir string, alg jwa.KeyAlgorithm, signGq bool) error {
+func sign(message string, outputDir string, signGq bool) error {
 	signer, pkt, err := loadLogin(outputDir)
 	if err != nil {
 		return fmt.Errorf("failed to load client state: %w", err)

--- a/examples/mfa/example.go
+++ b/examples/mfa/example.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/client/providers"
 	"github.com/openpubkey/openpubkey/examples/mfa/mfacosigner"
-	"github.com/openpubkey/openpubkey/util"
 )
 
 var (
@@ -64,17 +62,13 @@ func main() {
 	case "login":
 
 		opk := &client.OpkClient{
-			Op:   provider,
-			CosP: &cosignerProvider,
+			Op:          provider,
+			CosP:        &cosignerProvider,
+			ExtraClaims: map[string]any{},
+			SignGQ:      false,
 		}
 
-		clientKey, err := util.GenKeyPair(jwa.ES256)
-		if err != nil {
-			fmt.Println("error generating key pair:", err)
-			return
-		}
-
-		pkt, err := opk.Auth(context.TODO(), clientKey, jwa.ES256, map[string]any{}, false)
+		pkt, err := opk.Auth(context.TODO())
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/examples/mfa/example.go
+++ b/examples/mfa/example.go
@@ -61,11 +61,12 @@ func main() {
 	switch command {
 	case "login":
 
-		opk := &client.OpkClient{
-			Op:          provider,
-			CosP:        &cosignerProvider,
-			ExtraClaims: map[string]any{},
-			SignGQ:      false,
+		opk, err := client.New(provider,
+			client.WithCosignerProvider(&cosignerProvider),
+			client.WithSignGQ(false))
+		if err != nil {
+			fmt.Println(err)
+			return
 		}
 
 		pkt, err := opk.Auth(context.TODO())

--- a/examples/ssh/opkssh/cli.go
+++ b/examples/ssh/opkssh/cli.go
@@ -82,14 +82,13 @@ func main() {
 				os.Exit(1)
 			}
 
-			client := &client.OpkClient{
-				Op:     &op,
-				Signer: signer,
-				Alg:    alg,
-				SignGQ: false,
-			}
+			opkClient, err := client.New(
+				&op,
+				client.WithSigner(signer, alg),
+				client.WithSignGQ(false),
+			)
 
-			certBytes, seckeySshPem, err := createSSHCert(context.Background(), client, principals)
+			certBytes, seckeySshPem, err := createSSHCert(context.Background(), opkClient, principals)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -169,7 +168,7 @@ func createSSHCert(cxt context.Context, client *client.OpkClient, principals []s
 	if err != nil {
 		return nil, nil, err
 	}
-	sshSigner, err := ssh.NewSignerFromSigner(client.Signer)
+	sshSigner, err := ssh.NewSignerFromSigner(client.GetSigner())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -185,7 +184,7 @@ func createSSHCert(cxt context.Context, client *client.OpkClient, principals []s
 	}
 	certBytes := ssh.MarshalAuthorizedKey(sshCert)
 
-	seckeySsh, err := ssh.MarshalPrivateKey(client.Signer, "openpubkey cert")
+	seckeySsh, err := ssh.MarshalPrivateKey(client.GetSigner(), "openpubkey cert")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/examples/ssh/opkssh/cli.go
+++ b/examples/ssh/opkssh/cli.go
@@ -162,7 +162,6 @@ func authorizedKeysCommand(userArg string, typArg string, certB64Arg string, pol
 	}
 }
 
-
 func createSSHCert(cxt context.Context, client *client.OpkClient, principals []string) ([]byte, []byte, error) {
 	pkt, err := client.Auth(cxt)
 	if err != nil {


### PR DESCRIPTION
The main change is to take three of the five parameters to `client.Auth(...)` and move them into the client struct.

This the current definition of Auth:
``` golang
func (o *OpkClient) Auth(ctx context.Context, signer crypto.Signer, alg jwa.KeyAlgorithm, extraClaims map[string]any, signGQ bool) (*pktoken.PKToken, error) 
```

This is the definition of Auth after this PR:
``` golang
func (o *OpkClient) Auth(ctx context.Context, opts ...AuthOpts) (*pktoken.PKToken, error)
```

### OpkClient constructor

We then create a OpkClient  constructor that supports optional parameters via a variadic function. This lets us initialize these values with defaults but provides flexibility if developers want to override these defaults.

Creating an opkClient, all default values
```golang
opkClient, err := client.New(op)
```

Creating an opkClient overriding all default values
```golan
opkClient, err := client.New(
        op,
	client.WithCosignerProvider(&cosignerProvider),
	client.WithSigner(signer, alg),
	client.WithSignGQ(true))
```

## TODOs

- [X] Transform signer/alg/signGQ parameters in the `client.Auth` parameters to struct variables.
- [X] Moves the client unittest to use `client.Auth` rather than `client.OidcAuth`
- [X] Updates examples to use `client.Auth`
- [X] ExtraClaims as options list in `client.Auth`
- [X] OpkClient.New constructor with getters and setters
- [X] Tests for optional parameter passing to the constructor and auth
- [X] Package docs updates

## Why move them into the struct?

### Signer/Alg

The signer will be used by for the Cosigner Refresh and POP Auth client functions so it makes sense to bundle them as instance variables of the client. Additionally allows passing of the client into functions without also having to pass the signer and alg variables separately. For example look at how putting the signer and the alg into the struct cleans up the SSH example:

Before
```golang

client := &client.OpkClient{
     Op: &op,
}
gqFalse := false
certBytes, seckeySshPem, err := createSSHCert(context.Background(), client, signer, alg, gqFalse, principals)
...
func createSSHCert(cxt context.Context, client *client.OpkClient, signer crypto.Signer, alg jwa.KeyAlgorithm, gqFlag bool, principals []string) ([]byte, []byte, error) {
	pkt, err := client.Auth(cxt, signer, alg, map[string]any{}, gqFlag)
```

After
```golang
opkClient, err := client.New(
	&op,
	client.WithSigner(signer, alg),
	client.WithSignGQ(false),
)
certBytes, seckeySshPem, err := createSSHCert(context.Background(), opkClient, principals)
...
func createSSHCert(cxt context.Context, client *client.OpkClient, principals []string) ([]byte, []byte, error) {
	pkt, err := client.Auth(cxt)
```
This reduces the number of moving pieces and makes code written using the client simpler, more concise and removes the possibility bugs where another signer is substituted as the client signer.

This pattern allows users to bring their own signer using `WithSigner()`, but if they don't specify a signer we create a signer for them. This means that someone writing a simple app using OpenPubkey has to write much less boilerplate.

Before
```golang
opk := &client.OpkClient{
	Op:   &op
}
clientKey, err := util.GenKeyPair(jwa.ES256)
pkt, err := opk.Auth(context.TODO(), clientKey, jwa.ES256, map[string]any{}, false)
```

After
```
opkClient, err := client.New(&op)
pkt, err := opk.Auth(context.TODO())
```

This also enables login/logout functionality when a client can be torn down and the signer deleted.

### SignGQ

This follows the same justification as Signer/Alg. A client shouldn't want to mix GQ and non-GQ tokens. Configuring this up front when creating the client provides a single place to check how the client is configured. Someone wanted to audit that `SignGQ=true` only needs to check client creation, not each code path where Auth is called.

 ## Backwards compatibility?

No one is using the `client.Auth` method currently as it was just introduced in the last PR a few days ago. We can make this change with or without `client.New` without breaking anything downstream.