### PR TITLE
Adds the approved openpubkey Google clientid to all examples

### DIFF
--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -41,9 +41,9 @@ import (
 
 // Variables for building our google provider
 var (
-	clientID = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
-	// The clientSecret was intentionally checked in for the purposes of this example,. It holds no power. Do not report as a security issue
-	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
+	clientID = "992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com"
+	// The clientSecret was intentionally checked in. It holds no power and is used for development. Do not report as a security issue
+	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
 	scopes       = []string{"openid profile email"}
 	redirURIPort = "3000"
 	callbackPath = "/login-callback"

--- a/examples/ssh/opkssh/cli.go
+++ b/examples/ssh/opkssh/cli.go
@@ -36,11 +36,9 @@ import (
 )
 
 var (
-	key              = []byte("NotASecureKey123")
-	clientID         = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
-	requiredAudience = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
-	// The clientSecret was intentionally checked in for the purposes of this example,. It holds no power. Do not report as a security issue
-	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
+	clientID = "992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com"
+	// The clientSecret was intentionally checked in. It holds no power and is used for development. Do not report as a security issue
+	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
 	scopes       = []string{"openid profile email"}
 	redirURIPort = "3000"
 	callbackPath = "/login-callback"


### PR DESCRIPTION
This PR standardizes the examples apps to all use the same Google clientid. This clientid is approved by google and allows anyone to run the examples and the consent screen reads OpenPubkey. Some of clientid we were using had confusing consent screens.

Also deletes some unused configuration from the opkssh example.

I have manually tested this on all three examples.