### PR TITLE
Renames cosigner Iss to Issuer, fixes typos

### DIFF
--- a/cosigner/authcosigner.go
+++ b/cosigner/authcosigner.go
@@ -94,7 +94,7 @@ func (c *AuthCosigner) RedeemAuthcode(sig []byte) ([]byte, error) {
 func (c *AuthCosigner) IssueSignature(pkt *pktoken.PKToken, authState AuthState, authID string) ([]byte, error) {
 
 	protected := pktoken.CosignerClaims{
-		Iss:         c.Issuer,
+		Issuer:      c.Issuer,
 		KeyID:       c.KeyID,
 		Algorithm:   c.Alg.String(),
 		AuthID:      authID,

--- a/cosigner/cosigner_test.go
+++ b/cosigner/cosigner_test.go
@@ -45,7 +45,7 @@ func TestSimpleCosigner(t *testing.T) {
 	require.NoError(t, err, "failed to generate key pair")
 
 	cosignerClaims := pktoken.CosignerClaims{
-		Iss:         "example.com",
+		Issuer:      "example.com",
 		KeyID:       "none",
 		Algorithm:   cos.Alg.String(),
 		AuthID:      "none",

--- a/examples/mfa/mfacosigner/mfacosigner_test.go
+++ b/examples/mfa/mfacosigner/mfacosigner_test.go
@@ -159,7 +159,7 @@ func TestBadCosSigTyp(t *testing.T) {
 	for i, tc := range tests {
 
 		protected := pktoken.CosignerClaims{
-			Iss:         "https://example.com",
+			Issuer:      "https://example.com",
 			KeyID:       kid,
 			Algorithm:   string(alg),
 			AuthID:      "test-auth-id",

--- a/pktoken/cos.go
+++ b/pktoken/cos.go
@@ -31,7 +31,7 @@ import (
 )
 
 type CosignerClaims struct {
-	Iss         string `json:"iss"`
+	Issuer      string `json:"iss"`
 	KeyID       string `json:"kid"`
 	Algorithm   string `json:"alg"`
 	AuthID      string `json:"eid"`
@@ -51,7 +51,7 @@ func ParseCosignerClaims(protected []byte) (*CosignerClaims, error) {
 
 	// Check that all fields are present
 	var missing []string
-	if claims.Iss == "" {
+	if claims.Issuer == "" {
 		missing = append(missing, `iss`)
 	}
 	if claims.KeyID == "" {
@@ -115,7 +115,7 @@ func (p *PKToken) VerifyCosSig() error {
 		return fmt.Errorf("cosigner signature expired")
 	}
 
-	discConf, err := oidcclient.Discover(header.Iss, http.DefaultClient)
+	discConf, err := oidcclient.Discover(header.Issuer, http.DefaultClient)
 	if err != nil {
 		return fmt.Errorf("failed to call OIDC discovery endpoint: %w", err)
 	}

--- a/pktoken/osm.go
+++ b/pktoken/osm.go
@@ -91,12 +91,12 @@ func (p *PKToken) VerifySignedMessage(osm []byte) ([]byte, error) {
 		return nil, fmt.Errorf("missing required header `typ`")
 	}
 	if typ != "osm" {
-		return nil, fmt.Errorf(`incorrect "typ" header, expected "osm" but recieved %s`, typ)
+		return nil, fmt.Errorf(`incorrect "typ" header, expected "osm" but received %s`, typ)
 	}
 
 	// Verify key algorithm header matches cic
 	if protected.Algorithm() != cic.PublicKey().Algorithm() {
-		return nil, fmt.Errorf(`incorrect "alg" header, expected %s but recieved %s`, cic.PublicKey().Algorithm(), protected.Algorithm())
+		return nil, fmt.Errorf(`incorrect "alg" header, expected %s but received %s`, cic.PublicKey().Algorithm(), protected.Algorithm())
 	}
 
 	// Verify kid header matches hash of pktoken


### PR DESCRIPTION
Everywhere in our codebase we name the `iss` claim Issuer except in cosigner claims. This PR is based fixes this by renaming CosignerProvider.Iss to CosignerProvider.Issuer. @lgmugnier fixed this inconsistency in PR #88 but I broke it out into this smaller PR to get it into production faster.

Additionally this PR fixes a misspelling in an error message.

### Backwards Compatibility

Currently no one is using the CosignerProvider so while this rename of Iss would in theory break downstream, it is safe to do for now.