### PR TITLE
Fixes JWS signing bug where JSON unmarshalling breaks verification

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -200,9 +200,11 @@ func (o *OpkClient) OidcAuth(
 	}
 
 	// Use the commitment nonce to complete the OIDC flow and get an ID token from the provider
-	idTokenLB, err := o.Op.RequestTokens(ctx, string(nonce)) // idTokenLB is the ID Token in a
-	// memguard LockedBuffer, this is done because at this stage, if we are using GQ signatures,
-	// the ID Token may contain secrets we wish to protect.
+	idTokenLB, err := o.Op.RequestTokens(ctx, string(nonce))
+	// idTokenLB is the ID Token in a memguard LockedBuffer, this is done
+	// because the ID Token contains the OPs RSA signature which is a secret
+	// in GQ signatures. For non-GQ signatures OPs RSA signature is considered
+	// a public value.
 	if err != nil {
 		return nil, fmt.Errorf("error requesting ID Token: %w", err)
 	}

--- a/pktoken/cic.go
+++ b/pktoken/cic.go
@@ -17,19 +17,11 @@ func (p *PKToken) GetCicValues() (*clientinstance.Claims, error) {
 }
 
 func (p *PKToken) VerifyCicSig() error {
-	message := jws.NewMessage().
-		SetPayload(p.Payload).
-		AppendSignature(p.Cic)
-	token, err := jws.Compact(message)
-	if err != nil {
-		return err
-	}
-
 	cic, err := p.GetCicValues()
 	if err != nil {
 		return err
 	}
 
-	_, err = jws.Verify(token, jws.WithKey(cic.PublicKey().Algorithm(), cic.PublicKey()))
+	_, err = jws.Verify(p.CicToken, jws.WithKey(cic.PublicKey().Algorithm(), cic.PublicKey()))
 	return err
 }

--- a/pktoken/cic.go
+++ b/pktoken/cic.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package pktoken
 
 import (

--- a/pktoken/mocks/pktoken.go
+++ b/pktoken/mocks/pktoken.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package mocks
 
 import (
@@ -50,17 +66,24 @@ func GenerateMockPKTokenWithEmail(signingKey crypto.Signer, alg jwa.KeyAlgorithm
 		return nil, err
 	}
 
-	idToken, err := op.RequestTokens(context.Background(), string(nonce))
+	// idToken in memguard LockedBuffer
+	idTokenLB, err := op.RequestTokens(context.Background(), string(nonce))
 	if err != nil {
 		return nil, err
 	}
+	defer idTokenLB.Destroy()
+
+	// Make a copy of the bytes in the LockedBuffer as we no longer
+	// need the protection of LockedBuffer at this stage.
+	idToken := make([]byte, len(idTokenLB.Bytes()))
+	copy(idToken, idTokenLB.Bytes())
 
 	// Sign mock id token payload with cic headers
-	cicToken, err := cic.Sign(signingKey, jwkKey.Algorithm(), idToken.Bytes())
+	cicToken, err := cic.Sign(signingKey, jwkKey.Algorithm(), idToken)
 	if err != nil {
 		return nil, err
 	}
 
 	// Combine two tokens into a PK Token
-	return pktoken.New(idToken.Bytes(), cicToken)
+	return pktoken.New(idToken, cicToken)
 }

--- a/pktoken/pktoken_test.go
+++ b/pktoken/pktoken_test.go
@@ -1,10 +1,25 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package pktoken_test
 
 import (
 	"crypto"
 	_ "embed"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,14 +38,10 @@ func TestPkToken(t *testing.T) {
 	alg := jwa.ES256
 
 	signingKey, err := util.GenKeyPair(alg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	pkt, err := mocks.GenerateMockPKToken(signingKey, alg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	testPkTokenMessageSigning(t, pkt, signingKey)
 	testPkTokenSerialization(t, pkt)
@@ -40,38 +51,26 @@ func testPkTokenMessageSigning(t *testing.T, pkt *pktoken.PKToken, signingKey cr
 	// Create new OpenPubKey Signed Message (OSM)
 	msg := "test message!"
 	osm, err := pkt.NewSignedMessage([]byte(msg), signingKey)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Verify our OSM is valid
 	payload, err := pkt.VerifySignedMessage(osm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if string(payload) != msg {
-		t.Fatal("OSM payload did not match what we initially wrapped")
-	}
+	require.Equal(t, msg, string(payload), "OSM payload did not match what we initially wrapped")
 }
 
 func testPkTokenSerialization(t *testing.T, pkt *pktoken.PKToken) {
 	// Test json serialization/deserialization
 	pktJson, err := json.Marshal(pkt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Println(string(pktJson))
+	require.NoError(t, err)
 
 	var newPkt *pktoken.PKToken
-	if err := json.Unmarshal(pktJson, &newPkt); err != nil {
-		t.Fatal(err)
-	}
+	err = json.Unmarshal(pktJson, &newPkt)
+	require.NoError(t, err)
 
 	newPktJson, err := json.Marshal(newPkt)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	require.JSONEq(t, string(pktJson), string(newPktJson))
 }

--- a/pktoken/pktoken_test.go
+++ b/pktoken/pktoken_test.go
@@ -4,12 +4,14 @@ import (
 	"crypto"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/openpubkey/openpubkey/pktoken"
 	"github.com/openpubkey/openpubkey/pktoken/mocks"
+	"github.com/openpubkey/openpubkey/pktoken/simplejws"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -59,6 +61,7 @@ func testPkTokenSerialization(t *testing.T, pkt *pktoken.PKToken) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	fmt.Println(string(pktJson))
 
 	var newPkt *pktoken.PKToken
 	if err := json.Unmarshal(pktJson, &newPkt); err != nil {
@@ -71,6 +74,89 @@ func testPkTokenSerialization(t *testing.T, pkt *pktoken.PKToken) {
 	}
 
 	require.JSONEq(t, string(pktJson), string(newPktJson))
+}
+
+func TestPkTokenJwsUnchanged(t *testing.T) {
+	payload := `{
+		"aud": testAud
+		"email": "arthur.aardvark@example.com",
+		"exp": 1708641372,
+		"iat": 1708554972,
+		"iss": "me",
+		"nonce": "iOqVQfpJsbt4gpcGUX0lJLT82bTm8PU1fwNghiGau0M",
+		"sub": "1234567890"
+	  }`
+
+	// Alphabetical order A to Z
+	pheaderOpAz := `{"alg":"RS256","typ":"JWT"}`
+	pheaderCicAz := `{"alg":"ES256","rz":"872c6399f440d80a8c28935d8dd84da13ecdfc8e99b3dfbf92bdf1a3133a0b5e","typ":"CIC","upk":{"alg":"ES256","crv":"P-256","kty":"EC","x":"1UxCtDCjyb0bSz9P815sMTqGjSdF2u-sYk0egy4yigs","y":"0qQnHkOLMyQY5WwnpjaFO2TzGCtq_nFg10fI16LcexE"}}`
+	testUnchangedByCompact(t, payload, pheaderOpAz, pheaderCicAz)
+
+	// Reverse Alphabetical order Z to A
+	pheaderOpZa := `{"typ":"JWT","alg":"RS256"}`
+	pheaderCicZa := `{"upk":{"alg":"ES256","crv":"P-256","kty":"EC","x":"1UxCtDCjyb0bSz9P815sMTqGjSdF2u-sYk0egy4yigs","y":"0qQnHkOLMyQY5WwnpjaFO2TzGCtq_nFg10fI16LcexE"}, "typ":"CIC", "rz":"872c6399f440d80a8c28935d8dd84da13ecdfc8e99b3dfbf92bdf1a3133a0b5e", "alg":"ES256"}`
+	testUnchangedByCompact(t, payload, pheaderOpZa, pheaderCicZa)
+
+	// Whitespace
+	pheaderOpWs := `{  "alg":"RS256",     "typ":"JWT" }`
+	pheaderCicWs := `{ "alg":    "ES256",  "rz": "872c6399f440d80a8c28935d8dd84da13ecdfc8e99b3dfbf92bdf1a3133a0b5e" , "typ":"CIC","upk":{"alg":"ES256","crv":"P-256","kty":"EC","x":"1UxCtDCjyb0bSz9P815sMTqGjSdF2u-sYk0egy4yigs","y":"0qQnHkOLMyQY5WwnpjaFO2TzGCtq_nFg10fI16LcexE"}}`
+
+	testUnchangedByCompact(t, payload, pheaderOpWs, pheaderCicWs)
+	testUnchangedAfterMarshalling(t, payload, pheaderOpWs, pheaderCicWs)
+}
+
+func testUnchangedByCompact(t *testing.T, payload string, opPheader string, cicPheader string) {
+	pkt := &pktoken.PKToken{}
+
+	// Build OP Token and add it to PK Token
+	opTokenOriginal := BuildToken(opPheader, payload, "fakeSignature OP")
+	err := pkt.AddSignature(opTokenOriginal, pktoken.OIDC)
+	require.NoError(t, err)
+
+	// Check that Compact does not change original OP Token
+	opTokenOut, err := pkt.Compact(pkt.Op)
+	require.EqualValues(t, string(opTokenOriginal), string(opTokenOut), "danger, signed values in OP Token being changed")
+
+	// Build CIC Token and add it to PK Token
+	cicTokenOriginal := BuildToken(cicPheader, payload, "fakeSignature")
+	require.NotNil(t, cicTokenOriginal)
+	err = pkt.AddSignature(cicTokenOriginal, pktoken.CIC)
+	require.NoError(t, err)
+
+	// Check that Compact does not change original CIC Token
+	cicTokenCompact, err := pkt.Compact(pkt.Cic)
+	require.EqualValues(t, string(cicTokenOriginal), string(cicTokenCompact), "danger, signed values in CIC Token being changed")
+}
+
+func testUnchangedAfterMarshalling(t *testing.T, payload string, opPheader string, cicPheader string) {
+	pkt := &pktoken.PKToken{}
+
+	// Build OP Token and add it to PK Token
+	opTokenOriginal := BuildToken(opPheader, payload, "fakeSignature OP")
+	err := pkt.AddSignature(opTokenOriginal, pktoken.OIDC)
+	require.NoError(t, err)
+
+	// Build CIC Token and add it to PK Token
+	cicTokenOriginal := BuildToken(cicPheader, payload, "fakeSignature")
+	err = pkt.AddSignature(cicTokenOriginal, pktoken.CIC)
+	require.NoError(t, err)
+
+	// Check that Marshal PK Token to Json leaves underlying signed values unchanged
+	pktJson, err := pkt.MarshalJSON()
+	require.NoError(t, err)
+
+	// Unmarshal it into a simple JWS structure to see if the underlying values have changed
+	var simpleJWS simplejws.Jws
+	err = json.Unmarshal(pktJson, &simpleJWS)
+	require.NoError(t, err)
+
+	opTokenUnmarshalled, err := simpleJWS.GetTokenByTyp("JWT") // JWT is the token typ used by the OP Token (ID Token)
+	require.NoError(t, err)
+	require.EqualValues(t, string(opTokenOriginal), string(opTokenUnmarshalled), "danger, signed values in OP Token being changed during marshalling")
+
+	cicTokenUnmarshalled, err := simpleJWS.GetTokenByTyp("CIC") // CIC is the token typ used by the OP Token (ID Token)
+	require.NoError(t, err)
+	require.EqualValues(t, string(cicTokenOriginal), string(cicTokenUnmarshalled), "danger, signed values in CIC Token being changed during marshalling")
 }
 
 //go:embed test_jwk.json
@@ -91,4 +177,13 @@ func TestThumprintCalculation(t *testing.T) {
 	if string(thumbEnc) != fromRfc {
 		t.Fatalf("thumbprint %s did not match expected value %s", thumbEnc, fromRfc)
 	}
+}
+
+func BuildToken(protected string, payload string, sig string) []byte {
+	tokenStr := string(util.Base64EncodeForJWT([]byte(protected)))
+	tokenStr += "."
+	tokenStr += string(util.Base64EncodeForJWT([]byte(payload)))
+	tokenStr += "."
+	tokenStr += string(util.Base64EncodeForJWT([]byte(sig)))
+	return []byte(tokenStr)
 }

--- a/pktoken/simplejws/simplejws.go
+++ b/pktoken/simplejws/simplejws.go
@@ -71,7 +71,7 @@ func (j *Jws) AddSignature(token []byte, opts ...SigOpts) error {
 		applyOpt(sigOpts)
 	}
 
-	protected, payload, signature, err := jws.SplitCompact(token)
+	protected, payload, signature, err := SplitCompact(token)
 	if err != nil {
 		return err
 	}

--- a/pktoken/simplejws/simplejws.go
+++ b/pktoken/simplejws/simplejws.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package simplejws
 
 import (

--- a/pktoken/simplejws/simplejws.go
+++ b/pktoken/simplejws/simplejws.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/openpubkey/openpubkey/util"
 )
 

--- a/pktoken/simplejws/simplejws.go
+++ b/pktoken/simplejws/simplejws.go
@@ -1,0 +1,79 @@
+package simplejws
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openpubkey/openpubkey/util"
+)
+
+type Jws struct {
+	Payload    string      `json:"payload"`    // Base64 encoded
+	Signatures []Signature `json:"signatures"` // Base64 encoded
+}
+type Signature struct {
+	Protected string                 `json:"protected"` // Base64 encoded
+	Public    map[string]interface{} `json:"header,omitempty"`
+	Signature string                 `json:"signature"` // Base64 encoded
+}
+
+func (s *Signature) GetTyp() (string, error) {
+	decodedProtected, err := util.Base64DecodeForJWT([]byte(s.Protected))
+	if err != nil {
+		return "", err
+	}
+	type protectedTyp struct {
+		Typ string `json:"typ"`
+	}
+	var ph protectedTyp
+	err = json.Unmarshal(decodedProtected, &ph)
+	if err != nil {
+		return "", err
+	}
+	return ph.Typ, nil
+}
+
+func (j *Jws) GetToken(i int) ([]byte, error) {
+	if i < len(j.Signatures) && i >= 0 {
+		return []byte(j.Signatures[i].Protected + "." + j.Payload + "." + j.Signatures[i].Signature), nil
+	} else {
+		return nil, fmt.Errorf("no signature at index i (%d), len(signatures) (%d)", i, len(j.Signatures))
+	}
+}
+
+func (j *Jws) GetTokenByTyp(typ string) ([]byte, error) {
+	matchingTokens := []Signature{}
+	for _, v := range j.Signatures {
+		if typFound, err := v.GetTyp(); err != nil {
+			return nil, err
+		} else {
+			// Both the JWS standard and the OIDC standard states that typ is case sensitive
+			// so we treat it as case sensitive as well
+			//
+			// "The typ (type) header parameter is used to declare the type of the
+			// signed content. The typ value is case sensitive."
+			// https://openid.net/specs/draft-jones-json-web-signature-04.html#ReservedHeaderParameterName
+			//
+			// "The "typ" (type) Header Parameter is used by JWS applications to
+			// declare the media type [IANA.MediaTypes] of this complete JWS.
+			// [..] Per RFC 2045 [RFC2045], all media type values, subtype values, and
+			// parameter names are case insensitive. However, parameter values are case
+			// sensitive unless otherwise specified for the specific parameter."
+			// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9
+			if typFound == typ {
+				matchingTokens = append(matchingTokens, v)
+			}
+		}
+	}
+	if len(matchingTokens) > 1 {
+		// Currently we only have one token per token typ. We can change this later
+		// for COS tokens. This check prevents hidden tokens, where one token of
+		// the same typ hides another token of the same typ.
+		return nil, fmt.Errorf("more than one token found, all current token typs are unique")
+	} else if len(matchingTokens) == 0 {
+		// if typ not found return nil
+		return nil, nil
+	} else {
+		return []byte(matchingTokens[0].Protected + "." + j.Payload + "." + matchingTokens[0].Signature), nil
+	}
+}

--- a/pktoken/simplejws/simplejws_test.go
+++ b/pktoken/simplejws/simplejws_test.go
@@ -1,0 +1,91 @@
+package simplejws
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/openpubkey/openpubkey/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJwsMarshaling(t *testing.T) {
+	payloadJson := []byte(`{"a": "1", "b": 2}`)
+	// payloadB64 := string(util.Base64EncodeForJWT(tc.payload))
+
+	testCases := []struct {
+		name          string
+		payload       []byte
+		tokens        []string
+		publicHeaders []map[string]any
+		expectedJson  string
+	}{
+		{name: "with only payload",
+			payload:       payloadJson,
+			expectedJson:  `{"payload":"eyJhIjogIjEiLCAiYiI6IDJ9","signatures":[]}`,
+			publicHeaders: []map[string]any{},
+		},
+		{name: "with one token",
+			payload: payloadJson,
+			tokens: []string{
+				"eHl6.eyJhIjogIjEiLCAiYiI6IDJ9.ZmFrZXNpZ25hdHVyZQ=="},
+			expectedJson:  `{"payload":"eyJhIjogIjEiLCAiYiI6IDJ9","signatures":[{"protected":"eHl6","signature":"ZmFrZXNpZ25hdHVyZQ=="}]}`,
+			publicHeaders: []map[string]any{},
+		},
+		{name: "with two tokens",
+			payload: payloadJson,
+			tokens: []string{
+				"eHl6.eyJhIjogIjEiLCAiYiI6IDJ9.ZmFrZXNpZ25hdHVyZQ==",
+				"YWJj.eyJhIjogIjEiLCAiYiI6IDJ9.YW5vdGhlcmZha2VzaWc="},
+			publicHeaders: []map[string]any{},
+			expectedJson:  `{"payload":"eyJhIjogIjEiLCAiYiI6IDJ9","signatures":[{"protected":"eHl6","signature":"ZmFrZXNpZ25hdHVyZQ=="},{"protected":"YWJj","signature":"YW5vdGhlcmZha2VzaWc="}]}`,
+		},
+		{name: "with three tokens and public header",
+			payload: payloadJson,
+			tokens: []string{
+				"eHl6.eyJhIjogIjEiLCAiYiI6IDJ9.ZmFrZXNpZ25hdHVyZQ==",
+				"YWJj.eyJhIjogIjEiLCAiYiI6IDJ9.YW5vdGhlcmZha2VzaWc=",
+				"MTIz.eyJhIjogIjEiLCAiYiI6IDJ9.ZXh0cmFmYWtlc2ln"},
+			publicHeaders: []map[string]any{map[string]any{"a": "1", "b": 2}, nil, nil},
+			expectedJson:  `{"payload":"eyJhIjogIjEiLCAiYiI6IDJ9","signatures":[{"protected":"eHl6","header":{"a":"1","b":2},"signature":"ZmFrZXNpZ25hdHVyZQ=="},{"protected":"YWJj","signature":"YW5vdGhlcmZha2VzaWc="},{"protected":"MTIz","signature":"ZXh0cmFmYWtlc2ln"}]}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			jwsObj := Jws{
+				Payload:    string(util.Base64EncodeForJWT(tc.payload)),
+				Signatures: []Signature{},
+			}
+
+			for i, v := range tc.tokens {
+				token := []byte(v)
+				if i < len(tc.publicHeaders) {
+					public := tc.publicHeaders[i]
+					err := jwsObj.AddSignature(token, WithPublicHeader(public))
+					require.NoError(t, err)
+				} else {
+					err := jwsObj.AddSignature(token)
+					require.NoError(t, err)
+				}
+			}
+
+			jwsJson, err := json.Marshal(jwsObj)
+			require.NoError(t, err)
+			require.NotNil(t, jwsJson)
+
+			fmt.Println(string(jwsJson))
+			require.Equal(t, tc.expectedJson, string(jwsJson), "marshalled json doesn't match expected json")
+
+			var jwsObjUnmarshalled Jws
+			err = json.Unmarshal(jwsJson, &jwsObjUnmarshalled)
+			require.NoError(t, err)
+			JwsEqual(t, jwsObj, jwsObjUnmarshalled)
+		})
+	}
+}
+
+func JwsEqual(t *testing.T, j1 Jws, j2 Jws) {
+	require.Equal(t, j1.Payload, j2.Payload, "payloads don't match")
+	require.Equal(t, len(j1.Signatures), len(j1.Signatures))
+}


### PR DESCRIPTION
This fixes an bug where marshalling and unmarshalling the PK Token could break verification of the PK Token in semi-rare circumstances.

## Bug Description

PR #45 [Use jws signatures](https://github.com/openpubkey/openpubkey/pull/45) introduced a bug that in some circumstances break signature verification. 

JSON Marshalling/Unmarshalling json result in a different json representation. For instance  the json string `{"c": 1, "b": 2, "a": 3}` could be marshalled and unmarshalled to json string (with alphabetized keys): `{"a": 3, "b": 2, "c": 1}` 
as order of keys is not guaranteed to be preserved during marshaling. A signature over `{"c": 1, "b": 2, "a": 3}` will not verify for `{"a": 3, "b": 2, "c": 1}` even if semantically they are same object. This issue is not limited to only alphabetization, a similar problem exists for whitespace.

Prior to PR #45 we stored the original signed bytes of the OP, CIC and COS in the PK Token to ensure that the bytes we signed are the same bytes we used to construct the marshalled version of the PK Token for verification.
```
type PKToken struct {
	Payload []byte
	OpPH    []byte
	OpSig   []byte
...
```
PR #45 altered this behavior so that the bytes we signed were unmarshalled into a jws.signature object.
```
type Signature = jws.Signature

type PKToken struct {
	raw []byte // the original, raw representation of the object

	Payload []byte     // decoded payload
	Op      *Signature // Provider Signature
	Cic     *Signature // Client Signature
	Cos     *Signature // Cosigner Signature
```
This did not break verification for our current OP and it was only until experimenting with Azure that this bug was discovered.

## Fix
We fix this bug storing the signed tokens in the PK Token.
```
OpToken  []byte // Base64 encoded ID Token signed by the OP
CicToken []byte // Base64 encoded Token signed by the Client
CosToken []byte // Base64 encoded Token signed by the Cosigner
```
Then we plug these bytes for the fields in the json PK Token so that you always verify the exact bytes that were signed.

Additionally we needed to change the `pkt.Compact` function. `pkt.Compact` takes an unmarshalled signature and then produces the a compact token for verification. This assumes that the unmarshalled signature is safe to use for verificatio but there are several circumstances in which the returned compact token my not verify. To keep the lines of code in this PR low, this PR does not fully remove `pkt.Compact`. Instead it changes pkt.Compact` to simply return the saved compact token in the PK Token making it safe to use. We have marked FromCompact as depreciated and plan to remove it completely in a future PR.

Instead of `pkt.Compact`, developers should simply use the compact token saved to the PK Token.
Rather than:
```golang
cicToken, err := pkt.Compact(pkt.Cic)
```
do this instead:
```golang
cicToken := pkt.CicToken
```
In a future PR `pkt.Compact` will be removed.

## Regression Tests
We also created a regression test which creates a PK Token raw json strings and then we marshal and unmarshal the PK Token and check if the signed values are still equal to the original signed values. 

I tested this PR against the Google and MFA example tests on windows.

## TODOs:
- [X] Change unittests use a table test
- [X] Fix strange memory test failures that seem to happen randomly after this code change