### PR TITLE
Fixes bug in which JKT was being base64 encoded twice

### DIFF
--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -98,11 +98,10 @@ func TestClient(t *testing.T) {
 			if !ok {
 				t.Fatal("missing jkt header")
 			}
-			data, ok := jkt.([]byte)
+			jktstr, ok := jkt.(string)
 			if !ok {
-				t.Fatalf("expected jkt header to be a []byte, got %T", jkt)
+				t.Fatalf("expected jkt header to be a string, got %T", jkt)
 			}
-			jktstr := string(data)
 
 			pubkey, err := op.PublicKey(context.Background(), nil)
 			require.NoError(t, err, tc.name)

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -66,7 +66,10 @@ func (p *PKToken) AddJKTHeader(opKey crypto.PublicKey) error {
 	if headers == nil {
 		headers = jws.NewHeaders()
 	}
-	err = headers.Set("jkt", util.Base64EncodeForJWT(thumbprint))
+	thumbprintB64 := util.Base64EncodeForJWT(thumbprint)
+
+	// We make thumbprint a string otherwise jkt will Base64 encode it again
+	err = headers.Set("jkt", string(thumbprintB64))
 	if err != nil {
 		return fmt.Errorf("failed to set jkt claim: %w", err)
 	}


### PR DESCRIPTION
We base64 encode jkt (public key thumbprint) in the public header of the OP signature. However our json marshaller will automatically base64 encode an unknown header if it has the type []byte. 

This PR fixes this by changing the type of the jkt in the public header to string, rather than []byte.

This PR also adds a regression test for this bug fix.