### PR TITLE
Increases IssuedAt to one minute in Google Provider

### DIFF
--- a/client/providers/google.go
+++ b/client/providers/google.go
@@ -37,7 +37,8 @@ import (
 )
 
 var (
-	key = []byte("NotASecureKey123")
+	key            = []byte("NotASecureKey123")
+	issuedAtOffset = 1 * time.Minute
 )
 
 const googleIssuer = "https://accounts.google.com"
@@ -61,7 +62,7 @@ func (g *GoogleOp) RequestTokens(ctx context.Context, cicHash string) (*memguard
 	options := []rp.Option{
 		rp.WithCookieHandler(cookieHandler),
 		rp.WithVerifierOpts(
-			rp.WithIssuedAtOffset(5*time.Second), rp.WithNonce(
+			rp.WithIssuedAtOffset(issuedAtOffset), rp.WithNonce(
 				func(ctx context.Context) string { return cicHash })),
 	}
 	options = append(options, rp.WithPKCE(cookieHandler))
@@ -170,7 +171,7 @@ func (g *GoogleOp) PublicKey(ctx context.Context, headers jws.Headers) (crypto.P
 
 func (g *GoogleOp) VerifyNonGQSig(ctx context.Context, idt []byte, expectedNonce string) error {
 	options := []rp.Option{
-		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5*time.Second), rp.WithNonce(func(ctx context.Context) string { return expectedNonce })),
+		rp.WithVerifierOpts(rp.WithIssuedAtOffset(issuedAtOffset), rp.WithNonce(func(ctx context.Context) string { return expectedNonce })),
 	}
 
 	googleRP, err := rp.NewRelyingPartyOIDC(


### PR DESCRIPTION
Currently in the Google OpenID Provider we set the `WithIssuedAtOffset` to `5*time.Second` in Google to ensure that minor clock skew doesn't cause an ID Token to be rejected as being "from the future". Looking at other projects the standard values for this are:

* `3*time.Second`
* `5*time.Second`
*  `1*time.Minute`

This PR changes this value from `5*time.Second` --> `1*time.Minute` since it makes sense to be more forgiving. There is at least one bug report from a user #104 that was getting an error because their clock skew was 7 seconds off.

This does not impact the github OpenID Provider.