### PR TITLE
Creates integration test with github

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,9 @@ jobs:
   gotest:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -56,3 +59,4 @@ jobs:
 
     - name: Test
       run: go test ./...
+

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,0 +1,58 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/openpubkey/openpubkey/client"
+	"github.com/openpubkey/openpubkey/client/mocks"
+	"github.com/openpubkey/openpubkey/client/providers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGithub(t *testing.T) {
+	var op client.OpenIdProvider
+	var err error
+
+	if RunningInGithubActions() {
+		op, err = providers.NewGithubOpFromEnvironment()
+		require.NoError(t, err)
+	} else {
+		op, err = mocks.NewMockOpenIdProvider(t, map[string]any{})
+		require.NoError(t, err)
+	}
+
+	client, err := client.New(op, client.WithSignGQ(true))
+	require.NoError(t, err)
+
+	pkt, err := client.Auth(context.TODO())
+	require.NoError(t, err)
+	require.NotNil(t, pkt)
+	fmt.Println("New PK token generated")
+
+	err = op.Verifier().VerifyProvider(context.TODO(), pkt)
+	require.NoError(t, err)
+}
+
+func RunningInGithubActions() bool {
+	_, ok := os.LookupEnv("GITHUB_RUN_ID")
+	return ok
+}


### PR DESCRIPTION
This test uses a github-action to test the githubOP by requesting a ID Token from github and then building PK Token from this ID Token.

This is in response to PR #112 which fixed a bug in our githubOP which we had caught with testing. 

## Status of this PR

This is a fundamental issue that prevents this PR from working as it is currently written. As an open source project we at OpenPubkey want people to fork our repo and then submit PRs from their fork. As far as I can tell, github does not allow PRs from forks to request ID Tokens. Only PRs from the local branch can request ID Tokens. 

For instance if you request a ID Token from a fork you get the error:
`"ACTIONS_ID_TOKEN_REQUEST_URL" environment variable not set`

if you request a ID Token from a local branch, using the exact name code, it works. I've confirmed this behavior by creating a local branch PR https://github.com/openpubkey/openpubkey/pull/119 which successfully requests an ID Token. 

This limitation makes a lot of sense. Github views ID Tokens as powerful authentication secrets. Github allowed a forks to create a PR which adds a ID Token write permission to the github action workflow, then anyone could steal an ID Token by just PRing from a fork, adding the ID Token write permission and code which requests an ID Token and then exfiltrates it.

Possible solutions:

1. Run this test after a PR is merged as part of the release process. While this might caught a bug, I really don't like this approach because we should write tests to catch bugs earlier in the pipeline. It is better to spend our resources writing tests that run on every PR. Release tests are worth thinking about only once we have hit diminishing returns on unittests and integration tests.

2. Create a fake GithubOP that replicates Github's behavior accurately.  We have something pretty close to this in the GithubOP test we recently checked in. https://github.com/openpubkey/openpubkey/pull/112/files#diff-7d8ee697e94fe7f9636187dcc0abeff7282f038ce436d40cc09c852849e7688bR31 I'm not sure a full GithubOP simulation gets us better coverage.

3. Create a GithubOP example. This is similar to the release test approach, however it has the benefit of providing documentation in the form of a example. This could be turned into a test by adding a workflow which is triggered on a PR being merged into main.

I'm learning toward a GithubOP example. 

## TODOs

- [ ] Successfully pass new integration test
