### PR TITLE
Removes ability to set email in mock PK Token as it does not work

### DIFF
--- a/cosigner/cosigner_test.go
+++ b/cosigner/cosigner_test.go
@@ -31,18 +31,15 @@ func TestSimpleCosigner(t *testing.T) {
 	// Generate the key pair for our cosigner
 	alg := jwa.ES256
 	signer, err := util.GenKeyPair(alg)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err, "failed to generate key pair")
 
 	cos := &Cosigner{
 		Alg:    alg,
 		Signer: signer,
 	}
 
-	email := "arthur.aardvark@example.com"
-	pkt, err := mocks.GenerateMockPKTokenWithEmail(t, signer, alg, email)
-	require.NoError(t, err, "failed to generate key pair")
+	pkt, err := mocks.GenerateMockPKToken(t, signer, alg)
+	require.NoError(t, err)
 
 	cosignerClaims := pktoken.CosignerClaims{
 		Issuer:      "example.com",

--- a/examples/mfa/mfacosigner/mfacosigner_test.go
+++ b/examples/mfa/mfacosigner/mfacosigner_test.go
@@ -38,8 +38,7 @@ func TestFullFlow(t *testing.T) {
 	signer, err := util.GenKeyPair(alg)
 	require.NoError(t, err)
 
-	email := "arthur.aardvark@example.com"
-	pkt, err := mocks.GenerateMockPKTokenWithEmail(t, signer, alg, email)
+	pkt, err := mocks.GenerateMockPKToken(t, signer, alg)
 	require.NoError(t, err)
 
 	// Create our MFA Cosigner
@@ -124,8 +123,7 @@ func TestBadCosSigTyp(t *testing.T) {
 	signer, err := util.GenKeyPair(alg)
 	require.NoError(t, err)
 
-	email := "arthur.aardvark@example.com"
-	pkt, err := mocks.GenerateMockPKTokenWithEmail(t, signer, alg, email)
+	pkt, err := mocks.GenerateMockPKToken(t, signer, alg)
 	require.NoError(t, err)
 
 	// Create our MFA Cosigner

--- a/pktoken/mocks/pktoken.go
+++ b/pktoken/mocks/pktoken.go
@@ -29,11 +29,6 @@ import (
 )
 
 func GenerateMockPKToken(t *testing.T, signingKey crypto.Signer, alg jwa.KeyAlgorithm) (*pktoken.PKToken, error) {
-	return GenerateMockPKTokenWithEmail(t, signingKey, alg, "")
-}
-
-func GenerateMockPKTokenWithEmail(t *testing.T, signingKey crypto.Signer, alg jwa.KeyAlgorithm, email string) (*pktoken.PKToken, error) {
-
 	jwkKey, err := jwk.PublicKeyOf(signingKey)
 	if err != nil {
 		return nil, err
@@ -41,13 +36,6 @@ func GenerateMockPKTokenWithEmail(t *testing.T, signingKey crypto.Signer, alg jw
 	err = jwkKey.Set(jwk.AlgorithmKey, alg)
 	if err != nil {
 		return nil, err
-	}
-
-	if email != "" {
-		err = jwkKey.Set("email", email)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	cic, err := clientinstance.NewClaims(jwkKey, map[string]any{})


### PR DESCRIPTION
In PR https://github.com/openpubkey/openpubkey/pull/43 we introduced the ability to set the email claim in the mock PK Token for testing purposes. We did not use this testing feature and it did not work as intended. This removes this feature as it does nothing.