### PR TITLE
Minor bug fixes and upgrades

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.20.8
     
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.20.8
 
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.20.8
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To verify a signed message, we first verify that the PK Token `pkt` is issued by
 ```golang
 pktVerifier, err := verifier.New(provider.Verifier())
 err = pktVerifier.VerifyPKToken(context.Background(), pkt)
-msg, err := pkt.VerifySignedMessage(osm)
+msg, err := pkt.VerifySignedMessage(signedMsg)
 ```
 
 To run this example type: `go run .\examples\simple\example.go`.

--- a/client/mocks/oidp_server.go
+++ b/client/mocks/oidp_server.go
@@ -59,7 +59,7 @@ func NewOIDPServer(signer crypto.Signer, alg jwa.SignatureAlgorithm) (*OIDPServe
 	keySet.AddKey(jwkKey)
 
 	// Now convert our key set into the raw bytes for printing later
-	keySetBytes, _ := json.MarshalIndent(keySet, "", "  ")
+	keySetBytes, err := json.MarshalIndent(keySet, "", "  ")
 	if err != nil {
 		return nil, err
 	}

--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -80,7 +80,7 @@ func main() {
 		}
 	case "sign":
 		message := "sign me!!"
-		if err := sign(message, outputDir, signGQ); err != nil {
+		if err := sign(message, outputDir); err != nil {
 			fmt.Println("Failed to sign test message:", err)
 		}
 	default:
@@ -121,7 +121,7 @@ func login(outputDir string, signGQ bool) error {
 	return saveLogin(outputDir, opkClient.GetSigner().(*ecdsa.PrivateKey), pkt)
 }
 
-func sign(message string, outputDir string, signGq bool) error {
+func sign(message string, outputDir string) error {
 	signer, pkt, err := loadLogin(outputDir)
 	if err != nil {
 		return fmt.Errorf("failed to load client state: %w", err)


### PR DESCRIPTION
This PR has a bunch of minor fixes that don't need a full PR:

* Minor bug where we weren't setting an error variable but still checking err. Caught by a warning
* Removes unused function argument in example. Caught by a warning
* Github actions was complaining that the versions of the actions we were using were too old. This updates actions/checkout and actions/setup-go to new versions. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
