### PR TITLE
Creates code coverage github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - '**.go'
 
-permissions:
-  contents: write
-  pages: write
-
 jobs:
   gofmt:
     name: Check Code Formatting

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '**.go'
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   gofmt:
     name: Check Code Formatting
@@ -56,3 +60,5 @@ jobs:
 
     - name: Test
       run: go test ./...
+
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,5 +60,3 @@ jobs:
 
     - name: Test
       run: go test ./...
-
-

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,7 +2,7 @@ name: Go Checks
 
 on:
   push:
-    branches: [ "codecov" ]
+    branches: [ "main" ]
 
 permissions:
   contents: write

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,35 @@
+name: Go Checks
+
+on:
+  push:
+    branches: [ "codecov" ]
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+
+  codecov:
+    name: Push to main test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.20.8
+
+    - name: Test
+      run: go test ./...
+
+    - name: Update coverage report
+      uses: ncruces/go-coverage-report@v0
+      with:
+        report: true
+        chart: true
+        amend: true
+      if: github.event_name == 'push'
+      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OpenPubkey
+[![Go Coverage](https://github.com/ethanheilman/openpubkey/wiki/coverage.svg)](https://raw.githack.com/wiki/ethanheilman/openpubkey/coverage.html)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OpenPubkey
-[![Go Coverage](https://github.com/ethanheilman/openpubkey/wiki/coverage.svg)](https://raw.githack.com/wiki/ethanheilman/openpubkey/coverage.html)
+[![Go Coverage](https://github.com/openpubkey/openpubkey/wiki/coverage.svg)](https://raw.githack.com/wiki/openpubkey/openpubkey/coverage.html)
 
 ## Overview
 


### PR DESCRIPTION
Adds the ncruces/go-coverage-report@v0 code coverage tool to our github actions workflow. This is only run after a PR is merged to main. It is not run on every pull request.