### PR TITLE
Pass pointer to key.Raw()

### DIFF
--- a/client/providers/discover/discover.go
+++ b/client/providers/discover/discover.go
@@ -29,18 +29,31 @@ func NewPublicKeyRecord(key jwk.Key, issuer string) (*PublicKeyRecord, error) {
 	var pubKey interface{}
 	if key.Algorithm() == jwa.RS256 {
 		pubKey = new(rsa.PublicKey)
-	}
-	if key.Algorithm() == jwa.ES256 {
+	} else if key.Algorithm() == jwa.ES256 {
 		pubKey = new(ecdsa.PublicKey)
+	} else if key.Algorithm().String() == "" {
+		// OPs such as azure (microsoft) do not specify alg in their JWKS. To
+		// handle this case, assume no alg in JWKS means RSA as OIDC requires
+		// OPs use RSA.
+		pubKey = new(rsa.PublicKey)
+	} else {
+		return nil, fmt.Errorf("JWK has unsupported alg (%s)", key.Algorithm())
 	}
 	err := key.Raw(&pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode public key: %w", err)
 	}
 
+	var alg string
+	if key.Algorithm().String() == "" {
+		alg = jwa.RS256.String()
+	} else {
+		alg = key.Algorithm().String()
+	}
+
 	return &PublicKeyRecord{
 		PublicKey: pubKey,
-		Alg:       key.Algorithm().String(),
+		Alg:       alg,
 		Issuer:    issuer,
 	}, nil
 }

--- a/client/providers/discover/discover.go
+++ b/client/providers/discover/discover.go
@@ -33,7 +33,7 @@ func NewPublicKeyRecord(key jwk.Key, issuer string) (*PublicKeyRecord, error) {
 	if key.Algorithm() == jwa.ES256 {
 		pubKey = new(ecdsa.PublicKey)
 	}
-	err := key.Raw(pubKey)
+	err := key.Raw(&pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode public key: %w", err)
 	}


### PR DESCRIPTION
When testing with Microsoft as the OP, I received the following error:

```
failed to decode public key: destination argument to AssignIfCompatible() must be a pointer: <nil>
```

from:

https://github.com/openpubkey/openpubkey/blob/83be2414ed515ea18390b519c3c14936a1e05671/client/providers/discover/discover.go#L36-L39

After further investigation, it seems that we're failing because in the case of Microsoft `key.Algorithm() == nil`, so we're attempting the default case where we don't know the exact type of `jwk.Key`. Following the documentation of `jwk.Key.Raw()`,

> If you do not know the exact type of a jwk.Key before attempting to obtain the raw key, you can simply pass a pointer to an empty interface as the first argument.

I've changed the invocation of `Raw()` to pass a pointer to `pubKey`.
