### PR TITLE
Adds gitlab-ci OP using GQ commitment binding

### DIFF
--- a/client/providers/gitlab_ci.go
+++ b/client/providers/gitlab_ci.go
@@ -32,13 +32,19 @@ type GitlabOp struct {
 	issuer          string // Change issuer to point this to a test issuer
 	publicKeyFinder discover.PublicKeyFinder
 	getTokensFunc   func(string) (string, error)
+	tokenEnvVar     string
 }
 
-func NewGitlabOpFromEnvironment() (*GitlabOp, error) {
+func NewGitlabOpFromEnvironmentDefault() (*GitlabOp, error) {
+	return NewGitlabOpFromEnvironment("OPENPUBKEY_JWT")
+}
+
+func NewGitlabOpFromEnvironment(tokenEnvVar string) (*GitlabOp, error) {
 	op := &GitlabOp{
 		issuer:          gitlabIssuer,
 		publicKeyFinder: *discover.DefaultPubkeyFinder(),
 		getTokensFunc:   getEnvVar,
+		tokenEnvVar:     tokenEnvVar,
 	}
 	return op, nil
 }
@@ -66,7 +72,7 @@ func (g *GitlabOp) RequestTokens(ctx context.Context, cic *clientinstance.Claims
 		return nil, fmt.Errorf("error calculating client instance claim commitment: %w", err)
 	}
 
-	idToken, err := g.getTokensFunc("OPENPUBKEY-JWT")
+	idToken, err := g.getTokensFunc(g.tokenEnvVar)
 	if err != nil {
 		return nil, fmt.Errorf("error requesting ID Token: %w", err)
 	}

--- a/client/providers/gitlab_ci.go
+++ b/client/providers/gitlab_ci.go
@@ -1,0 +1,86 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/awnumar/memguard"
+	"github.com/openpubkey/openpubkey/client/providers/discover"
+	"github.com/openpubkey/openpubkey/pktoken/clientinstance"
+	"github.com/openpubkey/openpubkey/verifier"
+)
+
+const gitlabIssuer = "https://gitlab.com"
+
+type GitlabOp struct {
+	issuer          string // Change issuer to point this to a test issuer
+	publicKeyFinder discover.PublicKeyFinder
+	getTokensFunc   func(string) (string, error)
+}
+
+func NewGitlabOpFromEnvironment() (*GitlabOp, error) {
+	op := &GitlabOp{
+		issuer:          gitlabIssuer,
+		publicKeyFinder: *discover.DefaultPubkeyFinder(),
+		getTokensFunc:   getEnvVar,
+	}
+	return op, nil
+}
+
+func (g *GitlabOp) Verifier() verifier.ProviderVerifier {
+	return verifier.NewProviderVerifier(g.issuer, "", verifier.ProviderVerifierOpts{GQOnly: true, GQCommitment: true, SkipClientIDCheck: true})
+}
+
+func (g *GitlabOp) PublicKeyByToken(ctx context.Context, token []byte) (*discover.PublicKeyRecord, error) {
+	return g.publicKeyFinder.ByToken(ctx, g.issuer, token)
+}
+
+func (g *GitlabOp) PublicKeyByKeyId(ctx context.Context, keyID string) (*discover.PublicKeyRecord, error) {
+	return g.publicKeyFinder.ByKeyID(ctx, g.issuer, keyID)
+}
+
+func (g *GitlabOp) PublicKeyByJTK(ctx context.Context, jtk string) (*discover.PublicKeyRecord, error) {
+	return g.publicKeyFinder.ByJTK(ctx, g.issuer, jtk)
+}
+
+func (g *GitlabOp) RequestTokens(ctx context.Context, cic *clientinstance.Claims) ([]byte, error) {
+	// Define our commitment as the hash of the client instance claims
+	cicHash, err := cic.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("error calculating client instance claim commitment: %w", err)
+	}
+
+	idToken, err := g.getTokensFunc("OPENPUBKEY-JWT")
+	if err != nil {
+		return nil, err
+	}
+	idTokenLB := memguard.NewBufferFromBytes([]byte(idToken))
+
+	// idTokenLB is the ID Token in a memguard LockedBuffer, this is done
+	// because the ID Token contains the OPs RSA signature which is a secret
+	// in GQ signatures. For non-GQ signatures OPs RSA signature is considered
+	// a public value.
+	if err != nil {
+		return nil, fmt.Errorf("error requesting ID Token: %w", err)
+	}
+	defer idTokenLB.Destroy()
+	gqToken, err := CreateGQBoundToken(ctx, idTokenLB.Bytes(), g, string(cicHash))
+
+	return gqToken, err
+}

--- a/client/providers/gitlab_ci.go
+++ b/client/providers/gitlab_ci.go
@@ -35,18 +35,22 @@ type GitlabOp struct {
 	tokenEnvVar     string
 }
 
-func NewGitlabOpFromEnvironmentDefault() (*GitlabOp, error) {
+func NewGitlabOpFromEnvironmentDefault() *GitlabOp {
 	return NewGitlabOpFromEnvironment("OPENPUBKEY_JWT")
 }
 
-func NewGitlabOpFromEnvironment(tokenEnvVar string) (*GitlabOp, error) {
+func NewGitlabOpFromEnvironment(tokenEnvVar string) *GitlabOp {
+	return NewGitlabOp(gitlabIssuer, tokenEnvVar)
+}
+
+func NewGitlabOp(issuer string, tokenEnvVar string) *GitlabOp {
 	op := &GitlabOp{
-		issuer:          gitlabIssuer,
+		issuer:          issuer,
 		publicKeyFinder: *discover.DefaultPubkeyFinder(),
 		getTokensFunc:   getEnvVar,
 		tokenEnvVar:     tokenEnvVar,
 	}
-	return op, nil
+	return op
 }
 
 func (g *GitlabOp) Verifier() verifier.ProviderVerifier {

--- a/client/providers/gitlab_ci.go
+++ b/client/providers/gitlab_ci.go
@@ -68,17 +68,13 @@ func (g *GitlabOp) RequestTokens(ctx context.Context, cic *clientinstance.Claims
 
 	idToken, err := g.getTokensFunc("OPENPUBKEY-JWT")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error requesting ID Token: %w", err)
 	}
-	idTokenLB := memguard.NewBufferFromBytes([]byte(idToken))
-
 	// idTokenLB is the ID Token in a memguard LockedBuffer, this is done
 	// because the ID Token contains the OPs RSA signature which is a secret
 	// in GQ signatures. For non-GQ signatures OPs RSA signature is considered
 	// a public value.
-	if err != nil {
-		return nil, fmt.Errorf("error requesting ID Token: %w", err)
-	}
+	idTokenLB := memguard.NewBufferFromBytes([]byte(idToken))
 	defer idTokenLB.Destroy()
 	gqToken, err := CreateGQBoundToken(ctx, idTokenLB.Bytes(), g, string(cicHash))
 

--- a/client/providers/gitlab_ci_test.go
+++ b/client/providers/gitlab_ci_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/openpubkey/openpubkey/client/providers/discover"
+	"github.com/openpubkey/openpubkey/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitlabSimpleRequest(t *testing.T) {
+	expProtected := []byte(`{"kid": "test-kid","typ": "JWT","alg": "RS256"}`)
+	expPayload := []byte(`{"sha": "c7d5b5ff9b2130a53526dcc44a1f69ef0e50d003", "iat": 1710897326,"nbf": 1710897321,"exp": 1710900926,"sub": "project_path:openpubkey/gl-test:ref_type:branch:ref:main","aud": "OPENPUBKEY-PKTOKEN:1234"}`)
+
+	protected := jws.NewHeaders()
+	err := json.Unmarshal(expProtected, protected)
+	require.NoError(t, err)
+
+	algOp := jwa.RS256
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	expIdToken, err := jws.Sign(
+		expPayload,
+		jws.WithKey(
+			algOp,
+			signingKey,
+			jws.WithProtectedHeaders(protected),
+		),
+	)
+	require.NoError(t, err)
+
+	jwksFunc, err := discover.MockGetJwksByIssuerOneKey(signingKey.Public(), "test-kid", string(algOp))
+	require.NoError(t, err)
+
+	op := &GitlabOp{
+		issuer: gitlabIssuer,
+		publicKeyFinder: discover.PublicKeyFinder{
+			JwksFunc: jwksFunc,
+		},
+		getTokensFunc: func(envVarName string) (string, error) {
+			return string(expIdToken), nil
+		},
+	}
+
+	cic := genCIC(t)
+	idToken, err := op.RequestTokens(context.Background(), cic)
+	require.NoError(t, err)
+
+	cicHash, err := cic.Hash()
+	require.NoError(t, err)
+	require.NotNil(t, cicHash)
+
+	headerB64, _, _, err := jws.SplitCompact(idToken)
+	require.NoError(t, err)
+	headerJson, err := util.Base64DecodeForJWT(headerB64)
+	require.NoError(t, err)
+	headers := jws.NewHeaders()
+	err = json.Unmarshal(headerJson, &headers)
+	require.NoError(t, err)
+	cicHash2, ok := headers.Get("cic")
+	require.True(t, ok, "cic not found in GQ ID Token")
+
+	require.Equal(t, string(cicHash), cicHash2, "cic hash in jwt header should match cic supplied")
+}

--- a/client/providers/gq.go
+++ b/client/providers/gq.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package providers
 
 import (
@@ -12,11 +28,21 @@ import (
 )
 
 func CreateGQToken(ctx context.Context, idToken []byte, op OpenIdProvider) ([]byte, error) {
-	return CreateGQBoundToken(ctx, idToken, op, "")
+	return createGQTokenAllParams(ctx, idToken, op, "", false)
 }
 
 // TODO: I don't like this pattern, it is confusing the CreateGQToken calls CreateGQBoundToken even not doing a GQ Binding
 func CreateGQBoundToken(ctx context.Context, idToken []byte, op OpenIdProvider, cicHash string) ([]byte, error) {
+	return createGQTokenAllParams(ctx, idToken, op, cicHash, true)
+}
+
+func createGQTokenAllParams(ctx context.Context, idToken []byte, op OpenIdProvider, cicHash string, gqCommitment bool) ([]byte, error) {
+	if cicHash != "" && !gqCommitment {
+		// If gqCommitment is false, we will ignore the cicHash. This is a
+		// misconfiguration, and we should fail because the caller is likely
+		// expecting the cicHash to be included in the token.
+		return nil, fmt.Errorf("misconfiguration, cicHash is set but gqCommitment is false, set gqCommitment to true to include cicHash in the gq signature")
+	}
 	headersB64, _, _, err := jws.SplitCompact(idToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting original headers: %w", err)

--- a/client/providers/gq.go
+++ b/client/providers/gq.go
@@ -31,7 +31,6 @@ func CreateGQToken(ctx context.Context, idToken []byte, op OpenIdProvider) ([]by
 	return createGQTokenAllParams(ctx, idToken, op, "", false)
 }
 
-// TODO: I don't like this pattern, it is confusing the CreateGQToken calls CreateGQBoundToken even not doing a GQ Binding
 func CreateGQBoundToken(ctx context.Context, idToken []byte, op OpenIdProvider, cicHash string) ([]byte, error) {
 	return createGQTokenAllParams(ctx, idToken, op, cicHash, true)
 }

--- a/examples/gitlab/example.go
+++ b/examples/gitlab/example.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package gitlab_example
 
 import (

--- a/examples/gitlab/example.go
+++ b/examples/gitlab/example.go
@@ -1,0 +1,53 @@
+package gitlab_example
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openpubkey/openpubkey/client"
+	"github.com/openpubkey/openpubkey/client/providers"
+	"github.com/openpubkey/openpubkey/verifier"
+)
+
+func SignWithGitlab() error {
+
+	op, err := providers.NewGitlabOpFromEnvironment("OPENPUBKEY_JWT")
+	if err != nil {
+		return err
+	}
+	opkClient, err := client.New(op)
+	if err != nil {
+		return err
+	}
+
+	pkt, err := opkClient.Auth(context.Background())
+	if err != nil {
+		return err
+	}
+
+	pktJson, err := pkt.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	fmt.Println("pkt:", pktJson)
+
+	verifier, err := verifier.New(op.Verifier())
+	if err != nil {
+		return err
+	}
+
+	err = verifier.VerifyPKToken(context.Background(), pkt)
+	if err != nil {
+		return err
+	}
+
+	msg := []byte("All is discovered - flee at once")
+	signedMsg, err := pkt.NewSignedMessage(msg, opkClient.GetSigner())
+	if err != nil {
+		return err
+	}
+	fmt.Println("signedMsg:", string(signedMsg))
+
+	fmt.Println("Success!")
+	return nil
+}

--- a/verifier/providerverifier.go
+++ b/verifier/providerverifier.go
@@ -181,7 +181,7 @@ func (v *DefaultProviderVerifier) verifyCommitment(pkt *pktoken.PKToken) error {
 		// claim with the string "OPENPUBKEY-PKTOKEN:".
 		// We reject all GQ commitment PK Tokens that don't have this prefix
 		// in the aud claim.
-		if _, ok := strings.CutPrefix(AudPrefixForGQCommitment, aud.(string)); !ok {
+		if _, ok := strings.CutPrefix(aud.(string), AudPrefixForGQCommitment); !ok {
 			return fmt.Errorf("audience claim in PK Token's GQCommitment must be prefixed by (%s), got (%s) instead",
 				AudPrefixForGQCommitment, aud.(string))
 		}

--- a/verifier/providerverifier.go
+++ b/verifier/providerverifier.go
@@ -301,7 +301,7 @@ func verifyAudience(pkt *pktoken.PKToken, clientID string) error {
 	return nil
 }
 
-func VerifyCicSignature(pkt *pktoken.PKToken) error {
+func verifyCicSignature(pkt *pktoken.PKToken) error {
 	cic, err := pkt.GetCicValues()
 	if err != nil {
 		return err

--- a/verifier/providerverifier.go
+++ b/verifier/providerverifier.go
@@ -136,7 +136,7 @@ func (v *DefaultProviderVerifier) VerifyProvider(ctx context.Context, pkt *pktok
 		return err
 	}
 
-	if err := VerifyCicSignature(pkt); err != nil {
+	if err := verifyCicSignature(pkt); err != nil {
 		return fmt.Errorf("error verifying client signature on PK Token: %w", err)
 	}
 

--- a/verifier/providerverifier_test.go
+++ b/verifier/providerverifier_test.go
@@ -82,7 +82,7 @@ func TestProviderVerifier(t *testing.T) {
 			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
 			SkipClientIDCheck: true, correctCicHash: true, correctCicSig: true},
 		{name: "GQ Commitment wrong aud prefix", aud: "bad value",
-			expError:    "audience claim in PK Token's GQCommitment must be prefixed by (OPENPUBKEY-PKTOKEN:)",
+			expError:    "audience claim in PK Token's GQCommitment must be prefixed by",
 			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
 			SkipClientIDCheck: true, correctCicHash: true, correctCicSig: true},
 		{name: "GQ Commitment providerVerifier not using GQ Commitment", aud: correctAud,

--- a/verifier/providerverifier_test.go
+++ b/verifier/providerverifier_test.go
@@ -1,0 +1,140 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/openpubkey/openpubkey/pktoken"
+	"github.com/openpubkey/openpubkey/pktoken/mocks"
+	"github.com/openpubkey/openpubkey/util"
+	"github.com/openpubkey/openpubkey/verifier"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderVerifier(t *testing.T) {
+	correctAud := verifier.AudPrefixForGQCommitment
+	clientID := "test-client-id"
+
+	testCases := []struct {
+		name              string
+		aud               string
+		clientID          string
+		commitmentClaim   string
+		expError          string
+		pvGQSign          bool
+		pvGQOnly          bool
+		tokenGQSign       bool
+		tokenGQCommitment bool
+		pvGQCommitment    bool
+		SkipClientIDCheck bool
+		correctCicHash    bool
+		correctCicSig     bool
+	}{
+		{name: "Claim Commitment happy case", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError:       "",
+			correctCicHash: true, correctCicSig: true},
+		{name: "Claim Commitment wrong audience", commitmentClaim: "nonce", aud: "wrong clientID", clientID: clientID,
+			expError:       "audience does not contain clientID",
+			correctCicHash: true, correctCicSig: true},
+		{name: "Claim Commitment no commitment claim", commitmentClaim: "", aud: clientID, clientID: clientID,
+			expError:    "missing commitment claim",
+			tokenGQSign: false, correctCicHash: true, correctCicSig: true},
+		{name: "Claim Commitment wrong CIC", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError:    "commitment claim doesn't match",
+			tokenGQSign: false, correctCicHash: false, correctCicSig: true},
+		{name: "Claim Commitment bad sig on CIC", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError:    "error verifying client signature on PK Token: could not verify message using any of the signatures or keys",
+			tokenGQSign: false, correctCicHash: true, correctCicSig: false},
+		{name: "Claim Commitment bad sig on wrong CIC", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError: "commitment claim doesn't match", tokenGQSign: false, correctCicHash: false, correctCicSig: false},
+
+		{name: "Claim Commitment GQ happy case", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError: "", tokenGQSign: true, correctCicHash: true, correctCicSig: true},
+		{name: "Claim Commitment GQ no commitment claim", commitmentClaim: "", aud: clientID, clientID: clientID,
+			expError: "missing commitment claim", tokenGQSign: true, correctCicHash: true, correctCicSig: true},
+		{name: "Claim Commitment GQ wrong CIC", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError: "commitment claim doesn't match", tokenGQSign: true, correctCicHash: false, correctCicSig: true},
+		{name: "Claim Commitment GQ bad sig on CIC", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError:    "error verifying client signature on PK Token: could not verify message using any of the signatures or keys",
+			tokenGQSign: true, correctCicHash: true, correctCicSig: false},
+		{name: "Claim Commitment GQ bad sig on wrong CIC", commitmentClaim: "nonce", aud: clientID, clientID: clientID,
+			expError: "commitment claim doesn't match", tokenGQSign: true, correctCicHash: false, correctCicSig: false},
+
+		{name: "GQ Commitment happy case", aud: correctAud,
+			expError:    "",
+			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
+			SkipClientIDCheck: true, correctCicHash: true, correctCicSig: true},
+		{name: "GQ Commitment wrong aud prefix", aud: "bad value",
+			expError:    "audience claim in PK Token's GQCommitment must be prefixed by (OPENPUBKEY-PKTOKEN:)",
+			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
+			SkipClientIDCheck: true, correctCicHash: true, correctCicSig: true},
+		{name: "GQ Commitment providerVerifier not using GQ Commitment", aud: correctAud,
+			expError:    "missing commitment claim",
+			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: false,
+			SkipClientIDCheck: true, correctCicHash: true, correctCicSig: true},
+		{name: "GQ Commitment wrong CIC", aud: correctAud,
+			expError:    "commitment claim doesn't match",
+			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
+			SkipClientIDCheck: true, correctCicHash: false, correctCicSig: true},
+		{name: "GQ Commitment bad sig on CIC", aud: correctAud,
+			expError:    "error verifying client signature on PK Token: could not verify message using any of the signatures or keys",
+			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
+			SkipClientIDCheck: true, correctCicHash: true, correctCicSig: false},
+		{name: "GQ Commitment bad sig on wrong CIC", aud: correctAud,
+			expError:    "commitment claim doesn't match",
+			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
+			SkipClientIDCheck: true, correctCicHash: false, correctCicSig: false},
+		{name: "GQ Commitment check client id", aud: correctAud,
+			expError:    "GQCommitment requires that audience (aud) is not set to client-id",
+			tokenGQSign: true, tokenGQCommitment: true, pvGQOnly: true, pvGQCommitment: true,
+			SkipClientIDCheck: false, correctCicHash: false, correctCicSig: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			alg := jwa.ES256
+
+			signingKey, err := util.GenKeyPair(alg)
+			require.NoError(t, err)
+
+			var pkt *pktoken.PKToken
+			extraClaims := map[string]any{}
+			if tc.aud != "" {
+				extraClaims = map[string]any{
+					"aud": tc.aud,
+				}
+			}
+			pkt, err = mocks.GenerateMockPKTokenWithOpts(t, signingKey, alg, extraClaims, mocks.UseGQSign(tc.tokenGQSign), mocks.UseGQCommitment(tc.tokenGQCommitment), mocks.CorrectCicHash(tc.correctCicHash), mocks.CorrectCicSig(tc.correctCicSig))
+			require.NoError(t, err)
+
+			issuer, err := pkt.Issuer()
+			require.NoError(t, err)
+			pv := verifier.NewProviderVerifier(issuer, tc.commitmentClaim,
+				verifier.ProviderVerifierOpts{GQOnly: tc.pvGQOnly, GQCommitment: tc.pvGQCommitment, ClientID: tc.clientID, SkipClientIDCheck: tc.SkipClientIDCheck})
+			err = pv.VerifyProvider(context.Background(), pkt)
+
+			if tc.expError != "" {
+				require.ErrorContains(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -115,12 +115,12 @@ func (v *Verifier) VerifyPKToken(
 		return err
 	}
 
-	providerVerfier, ok := v.providers[issuer]
+	providerVerifier, ok := v.providers[issuer]
 	if !ok {
 		return fmt.Errorf("unrecognized issuer: %s", issuer)
 	}
 
-	if err := providerVerfier.VerifyProvider(ctx, pkt); err != nil {
+	if err := providerVerifier.VerifyProvider(ctx, pkt); err != nil {
 		return err
 	}
 

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -1,10 +1,25 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package verifier
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/openpubkey/openpubkey/gq"
 	"github.com/openpubkey/openpubkey/pktoken"
 )
@@ -142,11 +157,6 @@ func (v *Verifier) VerifyPKToken(
 			}
 		}
 	}
-
-	if err := VerifyCicSignature(pkt); err != nil {
-		return fmt.Errorf("error verifying client signature on PK Token: %w", err)
-	}
-
 	// Cycles through any provided additional checks and returns the first error, if any.
 	for _, check := range extraChecks {
 		if err := check(v, pkt); err != nil {
@@ -155,14 +165,4 @@ func (v *Verifier) VerifyPKToken(
 	}
 
 	return nil
-}
-
-func VerifyCicSignature(pkt *pktoken.PKToken) error {
-	cic, err := pkt.GetCicValues()
-	if err != nil {
-		return err
-	}
-
-	_, err = jws.Verify(pkt.CicToken, jws.WithKey(cic.PublicKey().Algorithm(), cic.PublicKey()))
-	return err
 }

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -162,6 +162,8 @@ func TestVerifier(t *testing.T) {
 
 func TestGQCommitment(t *testing.T) {
 
+	gqBindingAud := verifier.AudPrefixForGQCommitment + "1234"
+
 	testCases := []struct {
 		name         string
 		aud          string
@@ -170,7 +172,7 @@ func TestGQCommitment(t *testing.T) {
 		gqCommitment bool
 		gqOnly       bool
 	}{
-		{name: "happy case", aud: verifier.AudPrefixForGQCommitment, expError: "",
+		{name: "happy case", aud: gqBindingAud, expError: "",
 			gqSign: true, gqCommitment: true, gqOnly: true},
 		{name: "wrong aud prefix", aud: "bad value", expError: "error verifying PK Token: audience claim in PK Token's GQCommitment must be prefixed by",
 			gqSign: true, gqCommitment: true, gqOnly: true},

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package verifier_test
 
 import (
@@ -36,6 +52,18 @@ func TestVerifier(t *testing.T) {
 	pktVerifier, err := verifier.New(provider.Verifier())
 	require.NoError(t, err)
 	err = pktVerifier.VerifyPKToken(context.Background(), pkt)
+	require.NoError(t, err)
+
+	// Check if it handles more than one verifier
+	pktVerifierTwoProviders, err := verifier.New(provider.Verifier(), verifier.AddProviderVerifiers(providerGQ.Verifier()))
+	require.NoError(t, err)
+
+	opkClient, err = client.New(providerGQ)
+	require.NoError(t, err)
+	pktGQ, err := opkClient.Auth(context.Background())
+	require.NoError(t, err)
+
+	err = pktVerifierTwoProviders.VerifyPKToken(context.Background(), pktGQ)
 	require.NoError(t, err)
 
 	// Check if verification fails with incorrect issuer
@@ -130,4 +158,68 @@ func TestVerifier(t *testing.T) {
 	require.NoError(t, err)
 	err = pktVerifier.VerifyPKToken(context.Background(), pkt, verifier.GQOnly())
 	require.NoError(t, err)
+}
+
+func TestGQCommitment(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		aud          string
+		expError     string
+		gqSign       bool
+		gqCommitment bool
+		gqOnly       bool
+	}{
+		{name: "happy case", aud: verifier.AudPrefixForGQCommitment, expError: "",
+			gqSign: true, gqCommitment: true, gqOnly: true},
+		{name: "wrong aud prefix", aud: "bad value", expError: "error verifying PK Token: audience claim in PK Token's GQCommitment must be prefixed by",
+			gqSign: true, gqCommitment: true, gqOnly: true},
+		{name: "gqSign is false", aud: verifier.AudPrefixForGQCommitment, expError: "error requesting ID Token: if GQCommitment is true then GQSign must also be true",
+			gqSign: false, gqCommitment: true, gqOnly: true},
+		{name: "gqCommitment is false", aud: verifier.AudPrefixForGQCommitment, expError: "",
+			gqSign: true, gqCommitment: false, gqOnly: true},
+		{name: "gqOnly is false", aud: verifier.AudPrefixForGQCommitment, expError: "error verifying PK Token: GQCommitment requires that GQOnly is true, but GQOnly is (false)",
+			gqSign: true, gqCommitment: true, gqOnly: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			provider, err := mocks.NewMockOpenIdProvider(t, map[string]any{
+				"aud": tc.aud,
+			}, mocks.UseGQSign(tc.gqSign), mocks.UseGQCommitment(tc.gqCommitment), mocks.UseGQOnly(tc.gqOnly))
+
+			require.NoError(t, err)
+
+			opkClient, err := client.New(provider)
+			require.NoError(t, err)
+			pkt, err := opkClient.Auth(context.Background())
+
+			if tc.expError != "" {
+				require.ErrorContains(t, err, tc.expError)
+			} else {
+				cicHash, ok := pkt.Op.ProtectedHeaders().Get("cic")
+				if tc.gqCommitment == false {
+					require.False(t, ok)
+					require.Nil(t, cicHash)
+				} else {
+					require.True(t, ok)
+					require.NotNil(t, cicHash)
+
+					cic, err := pkt.GetCicValues()
+					require.NoError(t, err)
+					require.NotNil(t, cic)
+					cicHashFromCIC, err := cic.Hash()
+					require.NoError(t, err)
+					require.Equal(t, string(cicHashFromCIC), cicHash, "CIC does not match cicHash in GQ commitment")
+				}
+
+				require.NoError(t, err)
+				pktVerifier, err := verifier.New(provider.Verifier())
+				require.NoError(t, err)
+				err = pktVerifier.VerifyPKToken(context.Background(), pkt)
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR adds a gitlab-ci OP to OpenPubkey and assorted tests. Testing this feature required adding a number of new testing features and building out ProviderVerifier table based unittests.

## GQ Bound PK Tokens

For google and github we bind the CIC (Client Instance Claims) that contains the user's public key to the ID Token by putting a hashed commitment in one of the claims of the ID Token. For Google we put the commitment in the nonce claim, for github we put the commitment in the audience (aud) claim. Gitlab-CI does not provide an nonce claim and does not allow a running job/workflow to specify the aud. For gitlab the value of aud claim can only be specified in the static workflow config. This presents a problem: how to bind the CIC to the ID Token.

We provide a solution that solves this problem for gitlab-ci but also solves this problem more generally. We use the OP's RSA signature on the ID Token to create a GQ signature and then we delete the RSA signature. This GQ signature, functions as proof of knowledge of the RSA signature, enabling third parties to check that the ID Token was really signed by the OP. Additionally as the name suggests a GQ Signature is also a signature and use this signing property to bind the CIC to the ID Token. 

More specifically, put the commitment, a.k.a., the hash of the CIC, in the protected header of the GQ signed ID Token and then we GQ sign the payload and the protected header using the header claim "cic". Note that to ensure we don't lose the original protected header of the ID Token, we base64 encode it and set it as the kid (KeyID) in the GQ Signed ID Token's protected header. Below we show an example PK Token that uses a GQ commitment binding:

```go
payload: {
  "iss": "https://token.actions.gitlab.com",
  "aud": "OPENPUBKEY-PKTOKEN:1234",
  ...
} 
signatures: [
  {"protected": {"typ": "JWT", "alg": "GQ256", "kid":  Base64(origProtected), 
  "cic": SHA3_256(upk=alice-pubkey, alg=ES256, rz=crypto.Rand()),
  "signature": GQSIGN(RSA-sig, (payload, signatures[0].protected))`
  },
  {"protected": {"upk": alice-pubkey, "alg": "EC256", "rz": <rz>},
  "signature": <SIGN(alice-signkey, (payload, signatures[1].protected))>
  },
]
```

The design is based on the design proposed in https://github.com/openpubkey/openpubkey/issues/100 and should fix https://github.com/openpubkey/openpubkey/issues/26

## Security

If configured correctly, this is approach offers the same security as the approach used with github. However GQ bound PK Tokens do introduce a security risk from misconfiguration not present in the github case. The risk is that if a GQ signature is not used and an attacker learns the ID Token, the attacker can compute the GQ signature from the RSA signature and insert their own public key.

We mitigate the risk by:

* Requiring that PK Tokens that use the GQ signature to bind the CIC to the ID TOken must have "OPENPUBKEY-PKTOKEN:" prefixed in the audience and that they are not considered valid PK Tokens otherwise. This also prevents attacks in which a gitlab ID Token not intended for use as a PK Token is replayed as a PK Token. Note that this rule does not apply to other types of PK Tokens.
* Ensuring that OpenPubkey clients always enforces the deletion of the RSA signature and only generates GQ signature PK Tokens for gitlab. We use memguard to reduce the risk of exposure through process memory.

We argue that this sort of misconfiguration is very unlikely because outside of OpenPubkey, ID Tokens are treated as highly sensitive authentication secrets and within OpenPubkey we specifically prevent this misconfiguration from occurring. Someone must configure their gitlab to put "OPENPUBKEY-PKTOKEN:" in the aud claim, not use the OpenPubkey protocol and then in addition to that they must expose the ID token to an attacker. We can not prevent people from writing their own insecure protocols.

## TODOs
- [X] Add Gitlab OP
- [X] Add support for GQ commitment binding to gq library
- [X] Adversarial tests
- [X] Gitlab OP unittests
- [X] GQ commitment binding VerifierProvider unittests
- [X] Gitlab example
- [X] Create manual test to check this works on gitlab. Repo set for this purpose here: https://gitlab.com/openpubkey/gl-test
- [X] Allow specifying gitlab env variable to read ID Token from
- [X] Full PR description of change

## Tests

Successful OpenPubkey gitlab-CI job 
![image](https://github.com/openpubkey/openpubkey/assets/274814/97bdcd0a-7204-4ffb-86c2-185ea5273f6b)

* Gitlab-CI: Manually tested this PR for the commit e1c3d804b65fb88d52fe756530e32ea3bd0141be https://gitlab.com/openpubkey/gl-test/-/jobs/6474201669

* Github Actions: Manually tested this PR for the commit e1c3d804b65fb88d52fe756530e32ea3bd0141be https://github.com/openpubkey/gha-test/actions/runs/8426700367/job/23075582010

*  I have successfully manually tested mfa cosigner on firefox/chrome/edge. MFA cosigner on brave is breaking with the error `Error during registration: NotAllowedError: The operation either timed out or was not allowed. See: https://www.w3.org/TR/webauthn-2/#sctn-privacy-considerations-client.`It error is not related to these changes in this PR because I also tested against main and got the same error. I suspect something in a recent update to brave broke this.
