### PR TITLE
Adds a compact representation of a PK Token

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -75,7 +75,7 @@ func (id *OidcClaims) UnmarshalJSON(data []byte) error {
 // We include it here so so that jwx is not a dependency of simpleJws
 func SplitCompact(src []byte) ([]byte, []byte, []byte, error) {
 	parts := bytes.Split(src, []byte("."))
-	if len(parts) < 3 {
+	if len(parts) != 3 {
 		return nil, nil, nil, fmt.Errorf(`invalid number of segments`)
 	}
 	return parts[0], parts[1], parts[2], nil

--- a/pktoken/compact.go
+++ b/pktoken/compact.go
@@ -1,0 +1,86 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pktoken
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/openpubkey/openpubkey/oidc"
+)
+
+// CompactPKToken creates a compact representation of a PK Token from a list of tokens
+func CompactPKToken(tokens [][]byte, refIDToken []byte) ([]byte, error) {
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no tokens provided")
+	}
+
+	compact := [][]byte{}
+	var payload []byte
+	for _, tok := range tokens {
+		tokProtected, tokPayload, tokSig, err := oidc.SplitCompact(tok)
+		if err != nil {
+			return nil, err
+		}
+		if payload != nil {
+			if !bytes.Equal(payload, tokPayload) {
+				return nil, fmt.Errorf("payloads in tokens are not the same got %s and %s", payload, tokPayload)
+			}
+		} else {
+			payload = tokPayload
+		}
+		compact = append(compact, tokProtected, tokSig)
+	}
+	// prepend the payload to the front
+	compact = append([][]byte{payload}, compact...)
+	pktCom := bytes.Join(compact, []byte(":"))
+
+	// If we have a refreshed ID Token, append it to the compact representation using "."
+	if refIDToken != nil {
+		if len(bytes.Split(refIDToken, []byte("."))) != 3 {
+			// Compact ID Token should be reformated as Base64(protected)"."Base64(payload)"."Base64(signature)
+			return nil, fmt.Errorf("invalid refreshed ID Token")
+		}
+		pktCom = bytes.Join([][]byte{pktCom, refIDToken}, []byte("."))
+	}
+	return pktCom, nil
+}
+
+// SplitCompactPKToken breaks a compact representation of a PK Token into its constituent tokens
+func SplitCompactPKToken(pktCom []byte) ([][]byte, []byte, error) {
+	tokensBytes, refIDToken, _ := bytes.Cut(pktCom, []byte("."))
+	tokensParts := bytes.Split(tokensBytes, []byte(":"))
+
+	if refIDToken != nil && len(bytes.Split(refIDToken, []byte("."))) != 3 {
+		// Compact ID Token should be reformated as Base64(protected)"."Base64(payload)"."Base64(signature)
+		return nil, nil, fmt.Errorf("invalid refreshed ID Token")
+	}
+
+	// Compact PK Token with refreshed ID Token should have at least 3 parts and should be:
+	// Base64(payload)":"Base64(protected1)":"Base64(signature1)"...":"Base64(protectedN)":"Base64(signatureN)"
+	if len(tokensParts) < 3 || len(tokensParts)%2 != 1 {
+		return nil, nil, fmt.Errorf("invalid number of segments, got %d", len(tokensParts))
+	}
+	tokens := [][]byte{}
+	payload := tokensParts[0]
+	for i := 1; i < len(tokensParts); i += 2 {
+		// We return each token in JWT compact format (Base64(protected)"."Base64(payload)"."Base64(signature))
+		token := bytes.Join([][]byte{tokensParts[i], payload, tokensParts[i+1]}, []byte("."))
+		tokens = append(tokens, token)
+	}
+	return tokens, refIDToken, nil
+}

--- a/pktoken/compact_test.go
+++ b/pktoken/compact_test.go
@@ -1,0 +1,153 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pktoken
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCompact(t *testing.T) {
+	testCases := []struct {
+		name       string
+		tokens     [][]byte
+		refIDToken []byte
+		expError   string
+		expPktCom  []byte
+	}{
+		{name: "happy case one tokens",
+			tokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`)},
+			expPktCom: []byte(`ZmFrZSBwYXlsb2Fk:MWZha2Vwcm90ZWN0ZWQ:b25lIGZha2Ugc2ln`),
+		},
+		{name: "happy case two tokens",
+			tokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`),
+				// base64(two fake protected).base64(fake payload).base64(two fake sig)
+				[]byte(`dHdvIGZha2UgcHJvdGVjdGVk.ZmFrZSBwYXlsb2Fk.dHdvIGZha2Ugc2ln`)},
+			expPktCom: []byte(`ZmFrZSBwYXlsb2Fk:MWZha2Vwcm90ZWN0ZWQ:b25lIGZha2Ugc2ln:dHdvIGZha2UgcHJvdGVjdGVk:dHdvIGZha2Ugc2ln`),
+		},
+		{name: "happy case two tokens and refreshed ID Token",
+			tokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`),
+				// base64(two fake protected).base64(fake payload).base64(two fake sig)
+				[]byte(`dHdvIGZha2UgcHJvdGVjdGVk.ZmFrZSBwYXlsb2Fk.dHdvIGZha2Ugc2ln`)},
+			// base64(refreshed protected).base64(refreshed payload).base64(refreshed sig)
+			refIDToken: []byte(`cmVmcmVzaGVkIHByb3RlY3RlZA.cmVmcmVzaGVkIHBheWxvYWQ.cmVmcmVzaGVkIHNpZw`),
+			expPktCom:  []byte(`ZmFrZSBwYXlsb2Fk:MWZha2Vwcm90ZWN0ZWQ:b25lIGZha2Ugc2ln:dHdvIGZha2UgcHJvdGVjdGVk:dHdvIGZha2Ugc2ln.cmVmcmVzaGVkIHByb3RlY3RlZA.cmVmcmVzaGVkIHBheWxvYWQ.cmVmcmVzaGVkIHNpZw`),
+		},
+		{name: "different payloads",
+			expError: "payloads in tokens are not the same",
+			tokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`),
+				// base64(two fake protected).base64(different payload).base64(two fake sig)
+				[]byte(`dHdvIGZha2UgcHJvdGVjdGVk.ZGlmZmVyZW50IHBheWxvYWQ.dHdvIGZha2Ugc2ln`)},
+		},
+		{name: "malformed Token",
+			expError: "invalid number of segments",
+			tokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`),
+				// malformed token
+				[]byte(`..ZmFrZSBwYXl.sb2Fk.dHdvIGZha2Ugc2ln`)},
+		},
+		{name: "malformed Refreshed ID Token",
+			expError: "invalid refreshed ID Token",
+			tokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`),
+				// base64(two fake protected).base64(fake payload).base64(two fake sig)
+				[]byte(`dHdvIGZha2UgcHJvdGVjdGVk.ZmFrZSBwYXlsb2Fk.dHdvIGZha2Ugc2ln`)},
+			// base64(refreshed protected).base64(refreshed payload).base64(refreshed sig)
+			refIDToken: []byte(`***=BAD!!!###`),
+		},
+	}
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			pktCom, err := CompactPKToken(tc.tokens, tc.refIDToken)
+			if tc.expError != "" {
+				require.ErrorContains(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, string(tc.expPktCom), string(pktCom))
+			}
+		})
+	}
+}
+
+func TestFromCompact(t *testing.T) {
+	testCases := []struct {
+		name          string
+		expTokens     [][]byte
+		expRefIDToken []byte
+		expError      string
+		pktCom        []byte
+	}{
+		{name: "happy case one tokens",
+			expTokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`)},
+			pktCom: []byte(`ZmFrZSBwYXlsb2Fk:MWZha2Vwcm90ZWN0ZWQ:b25lIGZha2Ugc2ln`),
+		},
+		{name: "happy case two tokens",
+			// base64(one fake protected).base64(fake payload).base64(one fake sig)
+			expTokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`),
+				// base64(two fake protected).base64(fake payload).base64(two fake sig)
+				[]byte(`dHdvIGZha2UgcHJvdGVjdGVk.ZmFrZSBwYXlsb2Fk.dHdvIGZha2Ugc2ln`)},
+			pktCom: []byte(`ZmFrZSBwYXlsb2Fk:MWZha2Vwcm90ZWN0ZWQ:b25lIGZha2Ugc2ln:dHdvIGZha2UgcHJvdGVjdGVk:dHdvIGZha2Ugc2ln`),
+		},
+		{name: "happy case two tokens and refreshed ID Token",
+			expTokens: [][]byte{
+				// base64(one fake protected).base64(fake payload).base64(one fake sig)
+				[]byte(`MWZha2Vwcm90ZWN0ZWQ.ZmFrZSBwYXlsb2Fk.b25lIGZha2Ugc2ln`),
+				// base64(two fake protected).base64(fake payload).base64(two fake sig)
+				[]byte(`dHdvIGZha2UgcHJvdGVjdGVk.ZmFrZSBwYXlsb2Fk.dHdvIGZha2Ugc2ln`)},
+			// base64(refreshed protected).base64(refreshed payload).base64(refreshed sig)
+			expRefIDToken: []byte(`cmVmcmVzaGVkIHByb3RlY3RlZA.cmVmcmVzaGVkIHBheWxvYWQ.cmVmcmVzaGVkIHNpZw`),
+			pktCom:        []byte(`ZmFrZSBwYXlsb2Fk:MWZha2Vwcm90ZWN0ZWQ:b25lIGZha2Ugc2ln:dHdvIGZha2UgcHJvdGVjdGVk:dHdvIGZha2Ugc2ln.cmVmcmVzaGVkIHByb3RlY3RlZA.cmVmcmVzaGVkIHBheWxvYWQ.cmVmcmVzaGVkIHNpZw`),
+		},
+		{name: "malformed Compact PK Token (invalid number of segments)",
+			expError: "invalid number of segments",
+			pktCom:   []byte(`dHdvIGZha2Ugc2ln:dHdvIGZha2Ugc2ln.cmVmcmVzaGVkIHByb3RlY3RlZA.cmVmcmVzaGVkIHBheWxvYWQ.cmVmcmVzaGVkIHNpZw`),
+		},
+		{name: "malformed Compact PK Token (invalid refreshed ID Token)",
+			expError: "invalid refreshed ID Token",
+			pktCom:   []byte(`ZmFrZSBwYXlsb2Fk:MWZha2Vwcm90ZWN0ZWQ:b25lIGZha2Ugc2ln:dHdvIGZha2UgcHJvdGVjdGVk:dHdvIGZha2Ugc2ln.BAD.REFRESHED.ID.TOKEN`),
+		},
+	}
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			tokens, refIDToken, err := SplitCompactPKToken(tc.pktCom)
+			if tc.expError != "" {
+				require.ErrorContains(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expTokens, tokens)
+				require.Equal(t, tc.expRefIDToken, refIDToken)
+			}
+		})
+	}
+}

--- a/pktoken/pktoken_test.go
+++ b/pktoken/pktoken_test.go
@@ -73,6 +73,15 @@ func testPkTokenSerialization(t *testing.T, pkt *pktoken.PKToken) {
 	require.NoError(t, err)
 
 	require.JSONEq(t, string(pktJson), string(newPktJson))
+
+	com, err := newPkt.Compact()
+	require.NoError(t, err)
+	require.NotNil(t, com)
+
+	newPkt2 := &pktoken.PKToken{}
+	err = newPkt2.FromCompact(com)
+	require.NoError(t, err)
+	require.NotNil(t, newPkt2.OpToken)
 }
 
 func TestPkTokenJwsUnchanged(t *testing.T) {

--- a/pktoken/pktoken_test.go
+++ b/pktoken/pktoken_test.go
@@ -17,6 +17,7 @@
 package pktoken_test
 
 import (
+	"bytes"
 	"crypto"
 	_ "embed"
 	"encoding/json"
@@ -45,6 +46,15 @@ func TestPkToken(t *testing.T) {
 
 	testPkTokenMessageSigning(t, pkt, signingKey)
 	testPkTokenSerialization(t, pkt)
+
+	actualIssuer, err := pkt.Issuer()
+	require.NoError(t, err)
+	require.Equal(t, "mockIssuer", actualIssuer)
+
+	actualAlg, ok := pkt.ProviderAlgorithm()
+	require.True(t, ok)
+	require.Equal(t, "RS256", actualAlg.String())
+
 }
 
 func testPkTokenMessageSigning(t *testing.T, pkt *pktoken.PKToken, signingKey crypto.Signer) {
@@ -74,23 +84,28 @@ func testPkTokenSerialization(t *testing.T, pkt *pktoken.PKToken) {
 
 	require.JSONEq(t, string(pktJson), string(newPktJson))
 
-	com, err := newPkt.Compact()
+	// Simple Compact sanity test
+	pktCom, err := pkt.Compact()
 	require.NoError(t, err)
-	require.NotNil(t, com)
+	require.NotNil(t, pktCom)
 
-	newPkt2 := &pktoken.PKToken{}
-	err = newPkt2.FromCompact(com)
+	pktFromCom, err := pktoken.NewFromCompact(pktCom)
 	require.NoError(t, err)
-	require.NotNil(t, newPkt2.OpToken)
+	require.NotNil(t, pktFromCom.OpToken)
+	require.NotNil(t, pktFromCom.CicToken)
 }
 
+// This test builds a PK Token from a set of test vectors and then checks
+// that our serialization code preserves the exact values supplied as
+// test vectors. This is input because even minor whitespace or ordering
+// changes can break signature verification.
 func TestPkTokenJwsUnchanged(t *testing.T) {
 	payload := `{
-		"aud": testAud
+		"aud": "testAud",
 		"email": "arthur.aardvark@example.com",
 		"exp": 1708641372,
 		"iat": 1708554972,
-		"iss": "me",
+		"iss": "mockIssuer",
 		"nonce": "iOqVQfpJsbt4gpcGUX0lJLT82bTm8PU1fwNghiGau0M",
 		"sub": "1234567890"
 	  }`
@@ -123,42 +138,12 @@ func TestPkTokenJwsUnchanged(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testUnchangedByCompact(t, tc.payload, tc.opProtected, tc.cicProtected, tc.cosProtected)
-			testUnchangedAfterMarshalling(t, tc.payload, tc.opProtected, tc.cicProtected, tc.cosProtected)
+			testUnchanged(t, tc.payload, tc.opProtected, tc.cicProtected, tc.cosProtected)
 		})
 	}
 }
 
-// Once we remove pkt.Compact we can remove this test
-func testUnchangedByCompact(t *testing.T, payload string, opPheader string, cicPheader string, cosPheader string) {
-	pkt := &pktoken.PKToken{}
-
-	// Build OP Token and add it to PK Token
-	opTokenOriginal := BuildToken(opPheader, payload, "fakeSignature OP")
-	err := pkt.AddSignature(opTokenOriginal, pktoken.OIDC)
-	require.NoError(t, err)
-
-	// Check that Compact does not change original OP Token
-	require.EqualValues(t, string(opTokenOriginal), string(pkt.OpToken), "danger, signed values in OP Token being changed")
-
-	// Build CIC Token and add it to PK Token
-	cicTokenOriginal := BuildToken(cicPheader, payload, "fakeSignature")
-	err = pkt.AddSignature(cicTokenOriginal, pktoken.CIC)
-	require.NoError(t, err)
-
-	// Check that Compact does not change original CIC Token
-	require.EqualValues(t, string(cicTokenOriginal), string(pkt.CicToken), "danger, signed values in CIC Token being changed")
-
-	// Build COS Token and add it to PK Token
-	cosTokenOriginal := BuildToken(cosPheader, payload, "fakeSignature")
-	err = pkt.AddSignature(cosTokenOriginal, pktoken.COS)
-	require.NoError(t, err)
-
-	// Check that Compact does not change original COS Token
-	require.EqualValues(t, string(cosTokenOriginal), string(pkt.CosToken), "danger, signed values in COS Token being changed")
-}
-
-func testUnchangedAfterMarshalling(t *testing.T, payload string, opPheader string, cicPheader string, cosPheader string) {
+func testUnchanged(t *testing.T, payload string, opPheader string, cicPheader string, cosPheader string) {
 	pkt := &pktoken.PKToken{}
 
 	// Build OP Token and add it to PK Token
@@ -196,6 +181,124 @@ func testUnchangedAfterMarshalling(t *testing.T, payload string, opPheader strin
 	cosTokenUnmarshalled, err := simpleJWS.GetTokenByTyp("COS") // COS is the token typ used by the OP Token (ID Token)
 	require.NoError(t, err)
 	require.EqualValues(t, string(cosTokenOriginal), string(cosTokenUnmarshalled), "danger, signed values in CIC Token being changed during marshalling")
+
+	// Check that ToCompact and FromCompact leaves underlying signed values unchanged
+	pktCom, err := pkt.Compact()
+	require.NoError(t, err)
+	pktFromCom, err := pktoken.NewFromCompact(pktCom)
+	require.NoError(t, err)
+
+	require.EqualValues(t, string(opTokenOriginal), string(pktFromCom.OpToken), "danger, signed values in OP Token being changed after compact")
+	require.EqualValues(t, string(cicTokenOriginal), string(pktFromCom.CicToken), "danger, signed values in CIC Token being changed after compact")
+	require.EqualValues(t, string(cosTokenOriginal), string(pktFromCom.CosToken), "danger, signed values in COS Token being changed after compact")
+}
+
+// This test builds a PK Token from a set of test vectors and then checks
+// that the ToCompact constructs the PK Token correctly and that FromCompact
+// reconstructs the PK Token correctly.
+func TestCompact(t *testing.T) {
+	payload := `{
+		"aud": "testAud",
+		"email": "arthur.aardvark@example.com",
+		"exp": 1708641372,
+		"iat": 1708554972,
+		"iss": "mockIssuer",
+		"nonce": "iOqVQfpJsbt4gpcGUX0lJLT82bTm8PU1fwNghiGau0M",
+		"sub": "1234567890"
+	  }`
+
+	testCases := []struct {
+		name                string
+		payload             string
+		opProtected         string
+		cicProtected        string
+		cosProtected        string
+		expToCompactError   string
+		expFromCompactError string
+	}{
+		{name: "Happy case with OP, CIC tokens",
+			payload:      payload,
+			opProtected:  `{"alg":"RS256","typ":"JWT"}`,
+			cicProtected: `{"alg":"ES256","rz":"872c6399f440d80a8c28935d8dd84da13ecdfc8e99b3dfbf92bdf1a3133a0b5e","typ":"CIC","upk":{"alg":"ES256","crv":"P-256","kty":"EC","x":"1UxCtDCjyb0bSz9P815sMTqGjSdF2u-sYk0egy4yigs","y":"0qQnHkOLMyQY5WwnpjaFO2TzGCtq_nFg10fI16LcexE"}}`,
+		},
+		{name: "Happy case with OP, CIC and COS tokens",
+			payload:      payload,
+			opProtected:  `{"alg":"RS256","typ":"JWT"}`,
+			cicProtected: `{"alg":"ES256","rz":"872c6399f440d80a8c28935d8dd84da13ecdfc8e99b3dfbf92bdf1a3133a0b5e","typ":"CIC","upk":{"alg":"ES256","crv":"P-256","kty":"EC","x":"1UxCtDCjyb0bSz9P815sMTqGjSdF2u-sYk0egy4yigs","y":"0qQnHkOLMyQY5WwnpjaFO2TzGCtq_nFg10fI16LcexE"}}`,
+			cosProtected: `{"alg":"ES256","auth_time":1708991378,"eid":"1234","exp":1708994978,"iat":1708991378,"iss":"example.com","kid":"1234","nonce":"test-nonce","ruri":"http://localhost:3000","typ":"COS"}`,
+		},
+		{name: "No Tokens",
+			expToCompactError: "no tokens provided",
+			payload:           payload,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkt := &pktoken.PKToken{}
+
+			tokensAdded := 0
+			// Let's us test the case with no CIC Token.
+			if tc.opProtected != "" {
+				// Build OP Token and add it to PK Token
+				opTokenOriginal := BuildToken(tc.opProtected, tc.payload, "fakeSignature OP")
+				err := pkt.AddSignature(opTokenOriginal, pktoken.OIDC)
+				require.NoError(t, err)
+				tokensAdded += 1
+			}
+
+			// Let's us test the case with no CIC Token.
+			if tc.cicProtected != "" {
+				// Build CIC Token and add it to PK Token
+				cicTokenOriginal := BuildToken(tc.cicProtected, payload, "fakeSignature")
+				err := pkt.AddSignature(cicTokenOriginal, pktoken.CIC)
+				require.NoError(t, err)
+				tokensAdded += 1
+			}
+
+			// Let's us test the case with no COS Token. This is not an error case.
+			if tc.cosProtected != "" {
+				// Build CIC Token and add it to PK Token
+				cosTokenOriginal := BuildToken(tc.cosProtected, payload, "fakeSignature")
+				err := pkt.AddSignature(cosTokenOriginal, pktoken.COS)
+				require.NoError(t, err)
+				tokensAdded += 1
+			}
+
+			pktCom, err := pkt.Compact()
+			if tc.expToCompactError != "" {
+				require.ErrorContains(t, err, tc.expToCompactError)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, pktCom)
+				parts := bytes.Split(pktCom, []byte(":"))
+				expParts := tokensAdded*2 + 1
+				require.Equal(t, expParts, len(parts), "number of expected parts in compact (%d) does not match number of parts found (%d) ", expParts, len(parts))
+
+				// Try build a PK Token from the compact representation
+				pktFromCom, err := pktoken.NewFromCompact(pktCom)
+				if tc.expFromCompactError != "" {
+					require.ErrorContains(t, err, tc.expFromCompactError)
+				} else {
+					require.NoError(t, err)
+					require.NotNil(t, pktFromCom)
+
+					require.Equal(t, pkt.OpToken, pktFromCom.OpToken)
+					require.Equal(t, pkt.Op, pktFromCom.Op)
+
+					require.Equal(t, pkt.CicToken, pktFromCom.CicToken)
+					require.Equal(t, pkt.Cic, pktFromCom.Cic)
+
+					require.Equal(t, pkt.CosToken, pktFromCom.CosToken)
+					require.Equal(t, pkt.Cos, pktFromCom.Cos)
+
+					actualIssuer, err := pktFromCom.Issuer()
+					require.NoError(t, err)
+					require.Equal(t, "mockIssuer", actualIssuer)
+				}
+			}
+
+		})
+	}
 }
 
 //go:embed test_jwk.json


### PR DESCRIPTION
This PR adds the ability to represent a PK Token in a compact format, similar to the compact format used by JWTs. To test this functionality we add unittests and use this as an opportunity to clean up the pktoken unittests.

Fixes #166 
Fixes #31
Fixes #120

This change also sets up a format for sending and receiving refreshed ID Tokens when they are added to OpenPubkey, see #76

This change is valuable for reducing the size of pktokens when serialized. This is especially important because our SSH smuggling approach runs into a certificate size limit in older versions of SSH. A compact representation should give us significant headroom.

## Compact PK Token Representation

We use the compact PK Token representation prosed in #166 (see that issue for a deeper dive).

```golang
Base64(payload)+":"+Base64(OP protected)+":"+Base64(OP sig)+":"+Base64(CIC Protected)+":"+Base6464(CIC Sig)
```

To representing a Refreshed ID Token in this format we simple add it using "." to the compact token


```golang
Base64(payload)+":"+Base64(OP protected)+":"+Base64(OP sig)+":"+Base64(CIC Protected)+":"+Base6464(CIC Sig)
+"."+Base64(refreshed-protected)+"."+Base64(refreshed-payload)+"."+Base64(refreshed-sig)
```


## Tests

As none of this code touches github, google or gitlab, we do not perform any manual tests.