### PR TITLE
feat: Adds JKT (thumprint) to Protected Header of GQ Signed ID Tokens

### DIFF
--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -59,6 +59,7 @@ func TestClient(t *testing.T) {
 				Issuer:     "mockIssuer",
 				ClientID:   clientID,
 				GQSign:     tc.gq,
+				NumKeys:    2,
 				CommitType: commitType,
 				VerifierOpts: providers.ProviderVerifierOpts{
 					CommitType:        commitType,

--- a/examples/gitlab/example_test.go
+++ b/examples/gitlab/example_test.go
@@ -28,6 +28,7 @@ func TestGitlabExample(t *testing.T) {
 		Issuer:     "mockIssuer",
 		ClientID:   "mockClient-ID",
 		GQSign:     true,
+		NumKeys:    2,
 		CommitType: providers.CommitTypesEnum.GQ_BOUND,
 		VerifierOpts: providers.ProviderVerifierOpts{
 			SkipClientIDCheck: true,

--- a/examples/simple/example_test.go
+++ b/examples/simple/example_test.go
@@ -27,6 +27,7 @@ func TestGitlabExample(t *testing.T) {
 	providerOpts := providers.MockProviderOpts{
 		Issuer:     "mockIssuer",
 		GQSign:     true,
+		NumKeys:    2,
 		CommitType: providers.CommitTypesEnum.GQ_BOUND,
 		VerifierOpts: providers.ProviderVerifierOpts{
 			CommitType:        providers.CommitTypesEnum.GQ_BOUND,

--- a/examples/x509/example_test.go
+++ b/examples/x509/example_test.go
@@ -27,6 +27,7 @@ func TestSimpleExample(t *testing.T) {
 	providerOpts := providers.MockProviderOpts{
 		Issuer:     "mockIssuer",
 		GQSign:     true,
+		NumKeys:    2,
 		CommitType: providers.CommitTypesEnum.AUD_CLAIM,
 		VerifierOpts: providers.ProviderVerifierOpts{
 			CommitType:        providers.CommitTypesEnum.AUD_CLAIM,

--- a/oidc/sig.go
+++ b/oidc/sig.go
@@ -31,6 +31,7 @@ type Signature struct {
 
 type ProtectedClaims struct {
 	Alg   string `json:"alg"`
+	Jkt   string `json:"jkt,omitempty"`
 	KeyID string `json:"kid,omitempty"`
 	Type  string `json:"typ,omitempty"`
 	CIC   string `json:"cic,omitempty"`

--- a/pktoken/mocks/pktoken.go
+++ b/pktoken/mocks/pktoken.go
@@ -82,7 +82,7 @@ func GenerateMockPKTokenWithOpts(t *testing.T, signingKey crypto.Signer, alg jwa
 	providerOpts := providers.MockProviderOpts{
 		GQSign:     options.GQSign,
 		CommitType: options.CommitType,
-
+		NumKeys:    2,
 		VerifierOpts: providers.ProviderVerifierOpts{
 			SkipClientIDCheck: false,
 			GQOnly:            gqOnly,

--- a/providers/gq_test.go
+++ b/providers/gq_test.go
@@ -73,7 +73,7 @@ func TestGQ(t *testing.T) {
 
 			op, backend, idtTemplate, err := NewMockProvider(providerOpts)
 			require.NoError(t, err)
-			
+
 			expPublicKey := maps.Values(backend.GetProviderPublicKeySet())[0].PublicKey
 
 			idToken, err := idtTemplate.IssueToken()

--- a/providers/gq_test.go
+++ b/providers/gq_test.go
@@ -72,8 +72,8 @@ func TestGQ(t *testing.T) {
 			providerOpts.CommitType = tc.tokenCommitType
 
 			op, backend, idtTemplate, err := NewMockProvider(providerOpts)
-
 			require.NoError(t, err)
+			
 			expPublicKey := maps.Values(backend.GetProviderPublicKeySet())[0].PublicKey
 
 			idToken, err := idtTemplate.IssueToken()

--- a/providers/gq_test.go
+++ b/providers/gq_test.go
@@ -1,0 +1,119 @@
+// Copyright 2024 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/openpubkey/openpubkey/gq"
+	"github.com/openpubkey/openpubkey/oidc"
+	"github.com/openpubkey/openpubkey/util"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestGQ(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		tokenCommitType CommitType
+		gqCommitment    bool
+		cicHash         string
+		wrongAlg        bool
+		wrongKid        bool
+		expError        string
+	}{
+		{name: "happy case (nonce commit)",
+			tokenCommitType: CommitTypesEnum.NONCE_CLAIM,
+		},
+		{name: "happy case (GQ bound)",
+			tokenCommitType: CommitTypesEnum.GQ_BOUND,
+			gqCommitment:    true,
+			cicHash:         "fake-cic-hash",
+		},
+		{name: "change alg to ES256, should fail",
+			tokenCommitType: CommitTypesEnum.GQ_BOUND,
+			wrongAlg:        true,
+			expError:        "gq signatures require ID Token have signed with an RSA key, ID Token alg was (EC256)",
+		},
+		{name: "ID Token has kid that exist in OP's JWKS",
+			tokenCommitType: CommitTypesEnum.GQ_BOUND,
+			wrongKid:        true,
+			expError:        "no matching public key found for kid wrong-kid",
+		},
+		{name: "cicHash set but not GQ bound",
+			tokenCommitType: CommitTypesEnum.GQ_BOUND,
+			gqCommitment:    false,
+			cicHash:         "fake-cic-hash",
+			expError:        "misconfiguration, cicHash is set but gqCommitment is false",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			providerOpts := DefaultMockProviderOpts()
+			providerOpts.NumKeys = 1 // Only use 1 public key so we can find the public key used
+			providerOpts.CommitType = tc.tokenCommitType
+
+			op, backend, idtTemplate, err := NewMockProvider(providerOpts)
+
+			require.NoError(t, err)
+			expPublicKey := maps.Values(backend.GetProviderPublicKeySet())[0].PublicKey
+
+			idToken, err := idtTemplate.IssueToken()
+			require.NoError(t, err)
+
+			if tc.wrongAlg {
+				protected := util.Base64EncodeForJWT([]byte(`{"alg": "EC256","kid": "kid-0","typ": "JWT"}`))
+				idToken = []byte(string(protected) + ".e30.ZmFrZXNpZw")
+			}
+
+			if tc.wrongKid {
+				protected := util.Base64EncodeForJWT([]byte(`{"alg": "RS256","kid": "wrong-kid","typ": "JWT"}`))
+				idToken = []byte(string(protected) + ".e30.ZmFrZXNpZw")
+			}
+
+			gqToken, err := createGQTokenAllParams(context.Background(), idToken, op, tc.cicHash, tc.gqCommitment)
+
+			if tc.expError != "" {
+				require.ErrorContains(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, gqToken)
+
+				// Check that GQ Signature verifies
+				verifies, err := gq.GQ256VerifyJWT(expPublicKey.(*rsa.PublicKey), gqToken)
+				require.NoError(t, err)
+				require.True(t, verifies)
+
+				jwt, err := oidc.NewJwt(gqToken)
+				require.NoError(t, err)
+				typ, err := jwt.GetSignature().GetTyp()
+				require.NoError(t, err)
+				require.Equal(t, "JWT", typ)
+				jktFound := jwt.GetSignature().GetProtectedClaims().Jkt
+				require.NotEmpty(t, jktFound)
+
+				expJkt, err := createJkt(expPublicKey)
+				require.NoError(t, err)
+				require.Equal(t, expJkt, jktFound, "JKT in GQ ID Token does not match expected JKT")
+			}
+		})
+	}
+}

--- a/providers/mockprovider.go
+++ b/providers/mockprovider.go
@@ -33,6 +33,7 @@ type MockProviderOpts struct {
 	Issuer     string
 	ClientID   string
 	GQSign     bool
+	NumKeys    int
 	CommitType CommitType
 	// We keep VerifierOpts as a variable separate to let us test failures
 	// where the mock op does something which causes a verification failure
@@ -45,6 +46,7 @@ func DefaultMockProviderOpts() MockProviderOpts {
 		Issuer:     "https://accounts.example.com",
 		ClientID:   clientID,
 		GQSign:     false,
+		NumKeys:    2,
 		CommitType: CommitTypesEnum.NONCE_CLAIM,
 		VerifierOpts: ProviderVerifierOpts{
 			CommitType:        CommitTypesEnum.NONCE_CLAIM,
@@ -69,8 +71,7 @@ func NewMockProvider(opts MockProviderOpts) (OpenIdProvider, *mocks.MockProvider
 	if opts.Issuer == "" {
 		opts.Issuer = mockProviderIssuer
 	}
-	numKeys := 2
-	mockBackend, err := mocks.NewMockProviderBackend(opts.Issuer, numKeys)
+	mockBackend, err := mocks.NewMockProviderBackend(opts.Issuer, opts.NumKeys)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/providers/providerverifier_test.go
+++ b/providers/providerverifier_test.go
@@ -136,6 +136,7 @@ func TestProviderVerifier(t *testing.T) {
 				Issuer:     issuer,
 				ClientID:   clientID,
 				GQSign:     tc.tokenGQSign,
+				NumKeys:    2,
 				CommitType: tc.tokenCommitType,
 				VerifierOpts: ProviderVerifierOpts{
 					CommitType:        tc.pvCommitType,

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -38,6 +38,7 @@ func NewMockOpenIdProvider(gqSign bool, issuer string, clientID string, extraCla
 		Issuer:     issuer,
 		ClientID:   clientID,
 		GQSign:     gqSign,
+		NumKeys:    2,
 		CommitType: providers.CommitTypesEnum.NONCE_CLAIM,
 		VerifierOpts: providers.ProviderVerifierOpts{
 			CommitType:        providers.CommitTypesEnum.NONCE_CLAIM,
@@ -303,6 +304,7 @@ func TestGQCommitment(t *testing.T) {
 			providerOpts := providers.MockProviderOpts{
 				ClientID:   clientID,
 				GQSign:     tc.gqSign,
+				NumKeys:    2,
 				CommitType: commitType,
 				VerifierOpts: providers.ProviderVerifierOpts{
 					CommitType:        commitType,


### PR DESCRIPTION
OpenID Providers (OP) are not required to set kids (Key IDs) or use unique kids for the keys in their JWKS. It is extremely rare for an OP to not use an kid or to recycle a kid but it could happen. To ensure we can always find the correct public key to verify a ID Token, we record the JKT (JSON Key Thumbprint) of the OP's public key.

Currently when we serialize a PK Token as a JSON, we add the JTK to a public header. Unfortunately this approach does not work for compact representation of  PK Token because we want the compact representation only include signed data and public headers are not signed.

I made an realization that we only really care about JKTs for archival verification of messages signed my PK Tokens. When PK Tokens are used for signatures we always replay the RSA signature on the ID Token with a GQ signature (or in the future a ZKP signature). Thus, we only need to solve this problem for GQ signed PK Tokens. So why not just put the JKT claim in the GQ protected header of the ID Token? This solves all our problems with JKT!

The GQ signature covers the protected header so the JKT is now signed. Even better the GQ protected header is already included in the compact representation so we don't have to change the compact representation.

This PR puts the JKT in the protected header of the GQ Signature using under the key "jkt". This PR does not remove the code which adds the JKT to the PK Token when not using GQ Signatures. I'm of the opinion that it should remove it, but I want to discuss this with @jonnystoten first. I've created the issue to defer #178  and track this decision.

Fixes #172 

This solution was originally proposed here: https://github.com/openpubkey/openpubkey/issues/166#issuecomment-2040348944

## Tests

- [X] Github Actions manual test https://github.com/openpubkey/gha-test/actions/runs/8655405581/job/23734297610
- [X] Gitlab manual test https://gitlab.com/openpubkey/gl-test/-/pipelines/1250028405
- [X] MFA Cosigner manual test f9a1010d28907a1959e0562bd369a2e3522b64ea