### PR TITLE
feat: adds release drafter

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,58 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feat"
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    labels:
+      - "chore"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+autolabeler:
+  - label: "chore"
+    files:
+      - "*.md"
+    branch:
+      - '/docs{0,1}\/.+/'
+      - '/tests{0,1}\/.+/'
+    title:
+      - "/docs/i"
+      - "/test/i"
+  - label: "bug"
+    branch:
+      - '/fix\/.+/'
+      - '/revert\/.+/'
+    title:
+      - "/fix/i"
+      - "/revert/i"
+  - label: "feature"
+    branch:
+      - '/feature\/.+/'
+      - '/feat\/.+/'
+    title:
+      - "/feat/i"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-config.yml
+          publish: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
* Adds [release drafter](https://github.com/release-drafter/release-drafter) action and config file to draft GitHub releases with change notes generated on PR merges

## How-to Use
### Configuration
`.github/release-drafter-conig.yml` configures the format and behavior of release drafter according to configuration parameters (see [configuration-options](https://github.com/release-drafter/release-drafter?tab=readme-ov-file#configuration-options))

Change note categories are drafted based on labels applied to PRs. The current config will put changes under three categories (Features, Bug Fixes, or Maintenance) based on labels and all unlabeled PRs are categorized under a generic Changes.

### Auto labeling 
There is an autolabeler config that will automatically label PRs that use [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) types (e.g. fix, feat, chore, etc.) in the PR title or branch name with the appropriate label so that the changes are categorized in the release draft appropriately

### Releasing
To publish a drafted release. Edit the release in GitHub releases, manually format anything if desire and then `publish release`. For signed tags, push the appropriate signed tag for the drafted release prior to publishing (or the release tag will be signed by GitHub)

If there are any other workflows that need to run during a release, they can be triggered with the [release event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release). 

___
resolves https://github.com/openpubkey/openpubkey/issues/165