### PR TITLE
Adds golangci linter runner action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,56 +3,32 @@ name: Go Checks
 on:
   pull_request:
     paths:
-      - '**.go'
+      - "**.go"
 
 jobs:
-  gofmt:
-    name: Check Code Formatting
+  golangci-linter:
+    name: Run golangci linter
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.8
-    
-    - name: Check formatting
-      run: |
-        FILES=$(gofmt -l .)
-        if [ -n "$FILES" ]; then
-          echo "These files are not formatted correctly:"
-          echo "$FILES"
-          exit 1
-        fi
-
-  govet:
-    name: Vet Code
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.8
-
-    - name: Vet
-      run: go vet ./...
-
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.20"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.57
   gotest:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.8
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.8
 
-    - name: Test
-      run: go test ./...
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.20.8"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+linters:
+  enable:
+  # golangci-lint defaults 
+  # ref: https://golangci-lint.run/usage/linters/#enabled-by-default
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - unused
+  # additional
+  - misspell
+  - gofmt
+  fast: true
+run:
+  timeout: 5m

--- a/cosigner/mocks/authstatestore.go
+++ b/cosigner/mocks/authstatestore.go
@@ -119,7 +119,7 @@ func (s *AuthStateInMemoryStore) CreateNewAuthSession(pkt *pktoken.PKToken, ruri
 		return "", err
 	} else {
 		s.AuthStateMapLock.Lock()
-		if _, ok := s.AuthStateMap[authID]; ok != false {
+		if _, ok := s.AuthStateMap[authID]; ok {
 			return "", fmt.Errorf("specified authID is already in use")
 		}
 		s.AuthStateMap[authID] = authState
@@ -141,7 +141,7 @@ func (s *AuthStateInMemoryStore) CreateAuthcode(authID string) (string, error) {
 
 	if authState, ok := s.AuthStateMap[authID]; !ok {
 		return "", fmt.Errorf("no such authID")
-	} else if authState.AuthcodeIssued == true {
+	} else if authState.AuthcodeIssued {
 		return "", fmt.Errorf("authcode already issued for this authID")
 	} else {
 		s.AuthcodeMapLock.Lock()
@@ -168,11 +168,11 @@ func (s *AuthStateInMemoryStore) RedeemAuthcode(authcode string) (cosigner.AuthS
 		defer s.AuthStateMapLock.Unlock()
 
 		authState := s.AuthStateMap[authID]
-		if authState.AuthcodeIssued == false {
+		if !authState.AuthcodeIssued {
 			// This should never happen
 			return cosigner.AuthState{}, "", fmt.Errorf("no authcode issued for this authID")
 		}
-		if authState.AuthcodeRedeemed == true {
+		if authState.AuthcodeRedeemed {
 			return cosigner.AuthState{}, "", fmt.Errorf("authcode has already been redeemed")
 		}
 		authState.AuthcodeRedeemed = true

--- a/discover/discover_test.go
+++ b/discover/discover_test.go
@@ -324,13 +324,16 @@ func TestGQTokens(t *testing.T) {
 
 func CreateIDToken(t *testing.T, issuer string, signer crypto.Signer, alg string, kid string) []byte {
 	headers := jws.NewHeaders()
-	headers.Set(jws.AlgorithmKey, alg)
+	err := headers.Set(jws.AlgorithmKey, alg)
+	require.NoError(t, err)
 
 	// This lets us test JKT behavior when there is no kid
 	if kid != "" {
-		headers.Set(jws.KeyIDKey, kid)
+		err := headers.Set(jws.KeyIDKey, kid)
+		require.NoError(t, err)
 	}
-	headers.Set(jws.TypeKey, "JWT")
+	err = headers.Set(jws.TypeKey, "JWT")
+	require.NoError(t, err)
 
 	payload := map[string]any{
 		"sub": "me",

--- a/discover/mocks.go
+++ b/discover/mocks.go
@@ -34,13 +34,20 @@ func MockGetJwksByIssuer(publicKeys []crypto.PublicKey, keyIDs []string, algs []
 			return nil, err
 		}
 
-		jwkKey.Set(jwk.AlgorithmKey, algs[i])
+		if err := jwkKey.Set(jwk.AlgorithmKey, algs[i]); err != nil {
+			return nil, err
+		}
+
 		if keyIDs != nil {
-			jwkKey.Set(jwk.KeyIDKey, keyIDs[i])
+			if err := jwkKey.Set(jwk.KeyIDKey, keyIDs[i]); err != nil {
+				return nil, err
+			}
 		}
 
 		// Put our jwk into a set
-		jwks.AddKey(jwkKey)
+		if err := jwks.AddKey(jwkKey); err != nil {
+			return nil, err
+		}
 	}
 
 	jwksJson, err := json.Marshal(jwks)
@@ -60,12 +67,18 @@ func MockGetJwksByIssuerOneKey(publicKey crypto.PublicKey, keyID string, alg str
 		return nil, err
 	}
 
-	jwkKey.Set(jwk.AlgorithmKey, alg)
-	jwkKey.Set(jwk.KeyIDKey, keyID)
+	if err := jwkKey.Set(jwk.AlgorithmKey, alg); err != nil {
+		return nil, err
+	}
+	if err := jwkKey.Set(jwk.KeyIDKey, keyID); err != nil {
+		return nil, err
+	}
 
 	// Put our jwk into a set
 	jwks := jwk.NewSet()
-	jwks.AddKey(jwkKey)
+	if err := jwks.AddKey(jwkKey); err != nil {
+		return nil, err
+	}
 
 	jwksJson, err := json.Marshal(jwks)
 	if err != nil {

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -162,7 +162,7 @@ func (sv *signerVerifier) SignJWT(jwt []byte, opts ...Opts) ([]byte, error) {
 
 // modInverse finds the modular multiplicative inverse of the value stored in b
 //
-// All operations invovling the secret value are performed either with constant-
+// All operations involving the secret value are performed either with constant-
 // time methods or with blinding (if sv has a source of randomness)
 func (sv *signerVerifier) modInverse(b *memguard.LockedBuffer) (*memguard.LockedBuffer, error) {
 	x, err := bigmod.NewNat().SetBytes(b.Bytes(), sv.n)

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -38,9 +38,9 @@ type OidcClaims struct {
 	LastName   string `json:"family_name,omitempty"`
 }
 
-// Implement UnmarshalJSON for custom handling during JSON unmarshaling
+// Implement UnmarshalJSON for custom handling during JSON unmarshalling
 func (id *OidcClaims) UnmarshalJSON(data []byte) error {
-	// unmarshal audience claim seperately to account for []string, https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+	// unmarshal audience claim separately to account for []string, https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
 	type Alias OidcClaims
 	aux := &struct {
 		Audience any `json:"aud"`

--- a/providers/github_actions_test.go
+++ b/providers/github_actions_test.go
@@ -121,7 +121,8 @@ func TestGithubOpSimpleRequest(t *testing.T) {
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusOK)
-		res.Write([]byte(expResponseBody))
+		_, err := res.Write([]byte(expResponseBody))
+		require.NoError(t, err)
 	}))
 	defer func() { testServer.Close() }()
 
@@ -185,7 +186,8 @@ func TestGithubOpFullGQ(t *testing.T) {
 	expResponseBody := fmt.Sprintf(`{"count":1857,"value":"%s"}`, expIdToken)
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusOK)
-		res.Write([]byte(expResponseBody))
+		_, err := res.Write([]byte(expResponseBody))
+		require.NoError(t, err)
 	}))
 	defer func() { testServer.Close() }()
 

--- a/providers/google.go
+++ b/providers/google.go
@@ -150,6 +150,12 @@ func (g *GoogleOp) requestTokens(ctx context.Context, cicHash string) ([]byte, e
 		return uuid.New().String()
 	}
 
+	shutdownServer := func() {
+		if err := g.server.Shutdown(ctx); err != nil {
+			logrus.Errorf("Failed to shutdown http server: %v", err)
+		}
+	}
+
 	ch := make(chan []byte, 1)
 	chErr := make(chan error, 1)
 
@@ -175,9 +181,11 @@ func (g *GoogleOp) requestTokens(ctx context.Context, cicHash string) ([]byte, e
 		// MFA Cosigner Auth URI.
 		if g.httpSessionHook != nil {
 			g.httpSessionHook(w, r)
-			defer g.server.Shutdown(ctx) // If no http session hook is set, we do server shutdown in RequestTokens
+			defer shutdownServer() // If no http session hook is set, we do server shutdown in RequestTokens
 		} else {
-			w.Write([]byte("You may now close this window"))
+			if _, err := w.Write([]byte("You may now close this window")); err != nil {
+				logrus.Error(err)
+			}
 		}
 	}
 
@@ -193,7 +201,9 @@ func (g *GoogleOp) requestTokens(ctx context.Context, cicHash string) ([]byte, e
 
 	loginURI := fmt.Sprintf("http://localhost:%s/login", redirectURI.Port())
 	logrus.Infof("Opening browser to on http://%s/", loginURI)
-	util.OpenUrl(loginURI)
+	if err := util.OpenUrl(loginURI); err != nil {
+		logrus.Errorf("Failed to open url: %v", err)
+	}
 
 	// If httpSessionHook is not defined shutdown the server when done,
 	// otherwise keep it open for the httpSessionHook
@@ -202,12 +212,12 @@ func (g *GoogleOp) requestTokens(ctx context.Context, cicHash string) ([]byte, e
 	// 1. We shut it down if an error occurs in the marshalToken handler
 	// 2. We shut it down if the marshalToken handler completes
 	if g.httpSessionHook == nil {
-		defer g.server.Shutdown(ctx)
+		defer shutdownServer()
 	}
 	select {
 	case err := <-chErr:
 		if g.httpSessionHook != nil {
-			defer g.server.Shutdown(ctx)
+			defer shutdownServer()
 		}
 		return nil, err
 	case token := <-ch:

--- a/providers/mocks/backend.go
+++ b/providers/mocks/backend.go
@@ -56,11 +56,17 @@ func NewMockProviderBackend(issuer string, numKeys int) (*MockProviderBackend, e
 					if err != nil {
 						return nil, err
 					}
-					jwkKey.Set(jwk.AlgorithmKey, record.Alg)
-					jwkKey.Set(jwk.KeyIDKey, kid)
+					if err := jwkKey.Set(jwk.AlgorithmKey, record.Alg); err != nil {
+						return nil, err
+					}
+					if err := jwkKey.Set(jwk.KeyIDKey, kid); err != nil {
+						return nil, err
+					}
 
 					// Put our jwk into a set
-					keySet.AddKey(jwkKey)
+					if err := keySet.AddKey(jwkKey); err != nil {
+						return nil, err
+					}
 				}
 				return json.MarshalIndent(keySet, "", "  ")
 			},

--- a/providers/mocks/idtoken.go
+++ b/providers/mocks/idtoken.go
@@ -69,16 +69,24 @@ func (t *IDTokenTemplate) IssueToken() ([]byte, error) {
 
 	headers := jws.NewHeaders()
 	if !t.NoAlg {
-		headers.Set(jws.AlgorithmKey, t.Alg)
+		if err := headers.Set(jws.AlgorithmKey, t.Alg); err != nil {
+			return nil, err
+		}
 	}
 	if !t.NoKeyID {
-		headers.Set(jws.KeyIDKey, t.KeyID)
+		if err := headers.Set(jws.KeyIDKey, t.KeyID); err != nil {
+			return nil, err
+		}
 	}
-	headers.Set(jws.TypeKey, "JWT")
+	if err := headers.Set(jws.TypeKey, "JWT"); err != nil {
+		return nil, err
+	}
 
 	if t.ExtraProtectedClaims != nil {
 		for k, v := range t.ExtraProtectedClaims {
-			headers.Set(k, v)
+			if err := headers.Set(k, v); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/providers/mocks/idtoken.go
+++ b/providers/mocks/idtoken.go
@@ -60,7 +60,7 @@ func DefaultIDTokenTemplate() IDTokenTemplate {
 }
 
 // AddCommit adds the commitment to the CIC to the ID Token. The
-// CommitmentFunc is specifed allowing custom commitment functions to be specified
+// CommitmentFunc is specified allowing custom commitment functions to be specified
 func (t *IDTokenTemplate) AddCommit(cicHash string) {
 	t.CommitFunc(t, cicHash)
 }


### PR DESCRIPTION
Adds a [golang-ci](https://github.com/golangci/golangci-lint) action to lint incoming PRs. This is a linter runner that allows for configuring (`.golangci.yml` file at the root of the repo) and running many different linters in parallel.

I chose to enable all the [default linters suggested by golang-ci](https://golangci-lint.run/usage/linters/#enabled-by-default) as well as the following:

+ [gofmt](https://golangci-lint.run/usage/linters/#gofmt). This along with the default [govet](https://golangci-lint.run/usage/linters/#govet) linters can replace the steps in the workflow that were previously running `go fmt` and `go vet` checks as these checks are now subsumed by golangci linter.

+ [misspell](https://golangci-lint.run/usage/linters/#misspell) for catching spelling mistakes in variables/comments. Fixes #183 

This PR also fixes all the linter errors that were reported. I fixed each type of linter error in a separate commit. Most of the changes just required handling unchecked errors by either returning or logging the error in some cases or by using `require.NoError` to ensure error is nil within tests.