### PR TITLE
chore: Default to minor versions in release-drafter-config.yml

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -27,7 +27,7 @@ version-resolver:
   patch:
     labels:
       - "patch"
-  default: patch
+  default: minor
 template: |
   ## Changes
 


### PR DESCRIPTION
Currently each new branch is a minor version than a patch version. That is, 0.3.0, 0.4.0, 0.5.0 rather than 0.3.1, 0.3.2, ...

By setting the default to minor, we don't have to edit the release name the draft creates. Likely in the future when we have patch releases we will change this to patch.