### PR TITLE
feat: Client now returns a deep copy of the PK Token it generated

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -176,7 +176,7 @@ func (o *OpkClient) Auth(ctx context.Context, opts ...AuthOpts) (*pktoken.PKToke
 			return nil, err
 		}
 		o.pkToken = pkt
-		return o.pkToken, nil
+		return o.pkToken.DeepCopy()
 	}
 
 	// If a Cosigner is set then check that will support doing Cosigner auth
@@ -199,7 +199,7 @@ func (o *OpkClient) Auth(ctx context.Context, opts ...AuthOpts) (*pktoken.PKToke
 			return nil, err
 		}
 		o.pkToken = pktCos
-		return o.pkToken, nil
+		return o.pkToken.DeepCopy()
 	}
 }
 
@@ -287,7 +287,7 @@ func (o *OpkClient) Refresh(ctx context.Context) (*pktoken.PKToken, error) {
 		o.refreshToken = tokens.RefreshToken
 		o.accessToken = tokens.AccessToken
 
-		return o.pkToken, nil
+		return o.pkToken.DeepCopy()
 	}
 	return nil, fmt.Errorf("OP (issuer=%s) does not support OIDC refresh requests", o.Op.Issuer())
 }
@@ -318,6 +318,7 @@ func (o *OpkClient) SetPKToken(pkt *pktoken.PKToken) {
 	o.pkToken = pkt
 }
 
-func (o *OpkClient) GetPKToken() *pktoken.PKToken {
-	return o.pkToken
+// GetPKToken returns a deep copy of client's current PK Token
+func (o *OpkClient) GetPKToken() (*pktoken.PKToken, error) {
+	return o.pkToken.DeepCopy()
 }

--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -187,7 +187,8 @@ func TestClientRefreshErrorHandling(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, string(pkt1Com), string(pkt2Com))
 
-	pkt3 := c.GetPKToken()
+	pkt3, err := c.GetPKToken()
+	require.NoError(t, err)
 	pkt3com, err := pkt3.Compact()
 	require.NoError(t, err)
 	require.Equal(t, pkt2Com, pkt3com)

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -371,3 +371,17 @@ func (p *PKToken) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// DeepCopy creates a complete and independent copy of this PKToken,
+func (p *PKToken) DeepCopy() (*PKToken, error) {
+	pktJson, err := p.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	var pktCopy PKToken
+	if err := json.Unmarshal(pktJson, &pktCopy); err != nil {
+		return nil, err
+	}
+	pktCopy.FreshIDToken = p.FreshIDToken
+	return &pktCopy, nil
+}

--- a/pktoken/pktoken_test.go
+++ b/pktoken/pktoken_test.go
@@ -295,6 +295,23 @@ func TestCompact(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, "mockIssuer", actualIssuer)
 				}
+
+				// Test Deep Copy
+				pktCopy1, err := pkt.DeepCopy()
+				require.NoError(t, err)
+				pktCopy2, err := pkt.DeepCopy()
+				require.NoError(t, err)
+				require.Equal(t, pktCopy1.OpToken, pktCopy2.OpToken)
+				require.Equal(t, pktCopy1.Op, pktCopy2.Op)
+				require.Equal(t, pktCopy1.FreshIDToken, pktCopy2.FreshIDToken)
+
+				pktCopy1.OpToken = []byte("Overwritten-OP-Token")
+				pktCopy1.Op.SetSignature([]byte{0x0})
+				pktCopy1.FreshIDToken = []byte("Overwritten-Fresh-ID-Token")
+
+				require.NotEqual(t, pktCopy1.OpToken, pktCopy2.OpToken)
+				require.NotEqual(t, pktCopy1.Op, pktCopy2.Op)
+				require.NotEqual(t, pktCopy1.FreshIDToken, pktCopy2.FreshIDToken)
 			}
 
 		})


### PR DESCRIPTION
To avoid issues where the PK Token the client uses might be changed, this PR returns a reference to a deep copy of the PK Token rather than a reference to the PK Token.

I debated adding the refreshed ID Token to JSON representation in MarshallJSON, but it doesn't fit well into the JWS. I suppose I could add it as a public header, but I seems wrong to have a JWS inside a JWS public header. I could make MarshallJSON return a JSON object that contains the main pktoken JWS and then a separate JWS field. However that's a pretty big breaking change.

Right now if you want a serialization of a PK Token that includes the refreshed ID Token, use the compact representation.

Fixes https://github.com/openpubkey/openpubkey/issues/184

## Manual  Tests

- [X] MFA Cosigner a841f6e502149bed36f26631d793e108ab14c922
- [X] Github actions https://github.com/openpubkey/gha-test/actions/runs/8839034127/job/24271491043
- [X] Gitlab-CI https://gitlab.com/openpubkey/gl-test/-/pipelines/1268378182