### PR TITLE
bugfix: Infer signature is OIDC if type is missing from headers in `NewFromCompact`

### DIFF
--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -118,6 +118,11 @@ func NewFromCompact(pktCom []byte) (*PKToken, error) {
 			return nil, err
 		}
 		typ := parsedToken.GetSignature().GetProtectedClaims().Type
+		if typ == "" {
+			// missing typ claim, assuming this is from the OIDC provider
+			typ = string(OIDC)
+		}
+
 		sigType := SignatureType(typ)
 		if err := pkt.AddSignature(token, sigType); err != nil {
 			return nil, err

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -119,7 +119,13 @@ func NewFromCompact(pktCom []byte) (*PKToken, error) {
 		}
 		typ := parsedToken.GetSignature().GetProtectedClaims().Type
 		if typ == "" {
-			// missing typ claim, assuming this is from the OIDC provider
+			// missing typ claim, assuming this is from the OIDC provider and set typ=OIDC=JWT
+			// Okta is known not to set the typ parameter on their ID Tokens
+			// The JWT RFC-7519 encourages but does not require that typ be set saying about typ
+			//  "This parameter is ignored by JWT implementations; any processing of this parameter is
+			// performed by the JWT application.  If present, it is RECOMMENDED that its value be "JWT"
+			//  to indicate that this object is a JWT."
+			//  https://datatracker.ietf.org/doc/html/rfc7519#section-5.1
 			typ = string(OIDC)
 		}
 


### PR DESCRIPTION
Fixes issue where `NewFromCompact()` will return an error: `unrecognized signature type: ""` if the OP does not include `typ` claim in the protected headers of the JWS.

Follows similar logic as done here in `UnmarshalJSON()`:

https://github.com/openpubkey/openpubkey/blob/b38dc8dd734c98096c52f6ce6d27aeba7be7a22a/pktoken/pktoken.go#L324-L335

I encountered this issue when testing with Okta as the IdP