### PR TITLE
Upgrade to `golangci-lint-action@v5`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v5
         with:
           version: v1.57
   gotest:


### PR DESCRIPTION
In #201, I changed the workflow file to use `setup-go@v5`. We also need to upgrade the linter action for them to be compatible with one another.