### PR TITLE
bugfix: Adds policy file that can handle multiple emails

### DIFF
--- a/examples/ssh/opkssh/cli.go
+++ b/examples/ssh/opkssh/cli.go
@@ -68,9 +68,7 @@ func main() {
 	case "ver":
 		{
 			log(strings.Join(os.Args, " "))
-			policyEnforcer := simpleFilePolicyEnforcer{
-				PolicyFilePath: "/etc/opk/policy",
-			}
+			policyEnforcer := NewSimpleFilePolicyEnforcer("/etc/opk/policy")
 
 			if len(os.Args) != 5 {
 				fmt.Println("Invalid number of arguments for ver, should be `opkssh ver <User (TOKEN u)> <Cert (TOKEN k)> <Key type (TOKEN t)>`")

--- a/examples/ssh/opkssh/policy_test.go
+++ b/examples/ssh/opkssh/policy_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/openpubkey/openpubkey/client"
+	"github.com/openpubkey/openpubkey/providers"
+	"github.com/openpubkey/openpubkey/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyParse(t *testing.T) {
+
+	providerOpts := providers.DefaultMockProviderOpts()
+	op, _, template, err := providers.NewMockProvider(providerOpts)
+	require.NoError(t, err)
+	template.ExtraClaims = map[string]any{"email": "alice@example.com"}
+
+	alg := jwa.ES256
+	signer, err := util.GenKeyPair(alg)
+	require.NoError(t, err)
+	c, err := client.New(op, client.WithSigner(signer, alg))
+	require.NoError(t, err)
+
+	pkt, err := c.Auth(context.Background())
+	require.NoError(t, err)
+
+	policyEnforcer := simpleFilePolicyEnforcer{
+		PolicyFilePath: "/etc/opk/policy",
+		readPolicyFile: func() ([]byte, error) {
+			return []byte("alice@example.com test dev"), nil
+		},
+	}
+
+	err = policyEnforcer.checkPolicy("test", pkt)
+	require.NoError(t, err)
+
+	err = policyEnforcer.checkPolicy("dev", pkt)
+	require.NoError(t, err)
+
+	err = policyEnforcer.checkPolicy("root", pkt)
+	require.ErrorContains(t, err, "no policy to allow")
+
+	policyEnforcer = simpleFilePolicyEnforcer{
+		PolicyFilePath: "/etc/opk/policy",
+		readPolicyFile: func() ([]byte, error) {
+			return []byte("bob@example.com test bob\nalice@example.com test root"), nil
+		},
+	}
+
+	err = policyEnforcer.checkPolicy("root", pkt)
+	require.NoError(t, err)
+	err = policyEnforcer.checkPolicy("test", pkt)
+	require.NoError(t, err)
+	err = policyEnforcer.checkPolicy("bob", pkt)
+	require.ErrorContains(t, err, "no policy to allow")
+
+	template.ExtraClaims = map[string]any{"email": "bob@example.com"}
+	signer, err = util.GenKeyPair(alg)
+	require.NoError(t, err)
+	c, err = client.New(op, client.WithSigner(signer, alg))
+	require.NoError(t, err)
+
+	pkt2, err := c.Auth(context.Background())
+	require.NoError(t, err)
+
+	err = policyEnforcer.checkPolicy("test", pkt2)
+	require.NoError(t, err)
+	err = policyEnforcer.checkPolicy("bob", pkt2)
+	require.NoError(t, err)
+	err = policyEnforcer.checkPolicy("root", pkt2)
+	require.ErrorContains(t, err, "no policy to allow")
+
+}
+
+func TestPolicyParseFailures(t *testing.T) {
+
+	providerOpts := providers.DefaultMockProviderOpts()
+	op, _, template, err := providers.NewMockProvider(providerOpts)
+	require.NoError(t, err)
+	template.ExtraClaims = map[string]any{"email": "bob@example.com"}
+
+	alg := jwa.ES256
+	signer, err := util.GenKeyPair(alg)
+	require.NoError(t, err)
+	c, err := client.New(op, client.WithSigner(signer, alg))
+	require.NoError(t, err)
+
+	pkt, err := c.Auth(context.Background())
+	require.NoError(t, err)
+
+	policyEnforcer := simpleFilePolicyEnforcer{
+		PolicyFilePath: "/etc/opk/policy",
+		readPolicyFile: func() ([]byte, error) {
+			return []byte("alice@example.com test dev"), nil
+		},
+	}
+
+	err = policyEnforcer.checkPolicy("test", pkt)
+	require.ErrorContains(t, err, "no policy for email")
+
+	err = policyEnforcer.checkPolicy("dev", pkt)
+	require.ErrorContains(t, err, "no policy for email")
+
+	err = policyEnforcer.checkPolicy("root", pkt)
+	require.ErrorContains(t, err, "no policy for email")
+
+	policyEnforcer = simpleFilePolicyEnforcer{
+		PolicyFilePath: "/etc/opk/policy",
+		readPolicyFile: func() ([]byte, error) {
+			return nil, nil
+		},
+	}
+
+	err = policyEnforcer.checkPolicy("test", pkt)
+	require.ErrorContains(t, err, "policy file contained no policy")
+
+	policyEnforcer = simpleFilePolicyEnforcer{
+		PolicyFilePath: "/etc/opk/policy",
+		readPolicyFile: func() ([]byte, error) {
+			return []byte(""), nil
+		},
+	}
+
+	err = policyEnforcer.checkPolicy("test", pkt)
+	require.ErrorContains(t, err, "policy file contained no policy")
+}


### PR DESCRIPTION
Prior to this PR the ssh policy would only read the first line in the policy file. This allowed only one email address to be configured. For instance if `/etc/opk/policy` was:

```
bob@example.com test bob
alice@example.com alice root
```
Bob@example.com could login as the linux user test or bob, but the second and all subsequent lines would be ignored. 

After this PR, all lines in the policy file will read. This enables configuring more than one email in the policy file.

This PR also adds simple tests for the policy file.

Fixes https://github.com/openpubkey/openpubkey/issues/216

### Testing

I have manually tested this works with SSH on osx to ubuntu.
