### PR TITLE
Run go checks when go.mod and go.sum are changed

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "**.go"
+      - "go.mod"
+      - "go.sum"
 
 jobs:
   golangci-linter:


### PR DESCRIPTION
I noticed this didn't run on #218. This change means the checks run on dependabot PRs