### PR TITLE
Fixes issue where GQ library does not provide sufficient sounddness for RSA exponents that are not 65537

### DIFF
--- a/gq/gq.go
+++ b/gq/gq.go
@@ -132,6 +132,11 @@ func New256SignerVerifier(publicKey *rsa.PublicKey) (SignerVerifier, error) {
 //
 // The securityParameter parameter is the level of desired security in bits. 256 is recommended.
 func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int) (SignerVerifier, error) {
+	if publicKey.E != 65537 {
+		// Danger: Currently it is unsafe to use this library with a RSA exponent other than 65537.
+		// This issue is being tracked in https://github.com/openpubkey/openpubkey/issues/230
+		return nil, fmt.Errorf("only 65537 is currently supported, unsupported RSA public key exponent: %d", publicKey.E)
+	}
 	n, v, nBytes, vBytes, err := parsePublicKey(publicKey)
 	t := securityParameter / (vBytes * 8)
 

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -154,6 +154,17 @@ func TestVerifyModifiedGqPayload(t *testing.T) {
 
 }
 
+func TestRejectUnsupportedPublicKey(t *testing.T) {
+	oidcPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	oidcPrivKey.E = 3
+	oidcPubKey := &oidcPrivKey.PublicKey
+
+	signerVerifier, err := NewSignerVerifier(oidcPubKey, 256)
+	require.ErrorContains(t, err, "only 65537 is currently supported, unsupported RSA public key exponent")
+	require.Nil(t, signerVerifier)
+}
+
 func modifyTokenPayload(token []byte, audience string) ([]byte, error) {
 	headers, _, signature, err := jws.SplitCompact(token)
 	if err != nil {


### PR DESCRIPTION
On Feb 3 2025, Antonio Marcedone and Keegan Mehall from Zoom reported a vulnerability in the GQ library to OpenPubkey security email address. This PR is a short term fix for the vulnerability.

## Impact

This vulnerability only impacts people using the GQ library and only if you are using the GQ library with RSA public keys whose exponent is not 65537. 

- If you are just using OpenPubkey but not GQ you are not impacted.
-  If you are using OpenPubkey with GQ and one of the supported OpenID Providers you are not impacted as they all use 65537 for the public key exponent.

I am not aware of any current use of OpenPubkey in which someone would be impacted by this vulnerability. That said, the GQ library in OpenPubkey aims to be safe for uses outside of OpenPubkey and this vulnerability would impact its security if it was used outside of OpenPubkey.

While the number of impacted parties is likely zero, the effect of this bug on an impacted party would be the loss of soundness for GQ signatures. This would enable an attacker to convince our verifier that they had a validly signed message when they did not. 

This underlines the value of the OpenPubkey cosigner in that if someone was impacted by this vulnerability and they could have maintained security as the cosigner would have provided a redundant authentication check.

## Vulnerability

GQ signatures work by having a prover prove to a verifier they know a secret without revealing it. The way this proof works is that the prover commits to the value and then answers a random challenge $r$. The random challenge is chosen from the RSA public exponent $E$ where $0 \ge r < (E-1)$. A malicious prover can pass the challenge without actually have knowing the secret by getting lucky and guessing what challenge $r$ the verifier will ask. This means that for each challenge the prover has a $1/r$ chance of cheating at the protocol and winning. To ensure that the chance a verifier cheats and wins is cryptographically small, GQ repeats this challenge protocol $t$ times. Since cheating verifier must win all $t$, the soundness of a GQ signature is $r^t$.

Consider the case when the RSA public exponent E is 3 and you want 256-bit security. As $log2(3^{162}) = 256.76$ you need $t=162$ challenges to have 256-bit soundness. The problem is the GQ code computes $t$ incorrectly and for $E=3$ only requires $t=32$ challenges.

As shown below, given $E=3$ the function `parsePublicKey` will set $v=3$ and $vBytes=1$. Consequently `NewSignerVerifier` will set $t=32$ when the security parameter is set to the default $256$. 

`t := securityParameter=256 / (vBytes=1 * 8)`

Repeating this $t=32$ times only gives us $log2(3^{32})=50.71$ bits of soundness when $256$ bits of soundness has been requested. The core mistake here is computing the number of challenges assuming we get soundness equal to the byte length of the exponent, while this is safe to do $E=65536$, it is not safe for other values like $E=3$.

```golang
func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int) (SignerVerifier, error) {
	n, v, nBytes, vBytes, err := parsePublicKey(publicKey)
	t := securityParameter / (vBytes * 8)

	return &signerVerifier{n, v, nBytes, vBytes, t}, err
}

func parsePublicKey(publicKey *rsa.PublicKey) (n *bigmod.Modulus, v *big.Int, nBytes int, vBytes int, err error) {
	n, err = bigmod.NewModulusFromBig(publicKey.N)
	if err != nil {
		return
	}
	v = big.NewInt(int64(publicKey.E))
	nLen := n.BitLen()
	vLen := v.BitLen() - 1 // note the -1; GQ1 only ever uses the (length of v) - 1, so we can just do this here rather than throughout
	nBytes = bytesForBits(nLen)
	vBytes = bytesForBits(vLen)
	return
}

func bytesForBits(bits int) int {
	return (bits + 7) / 8
}
```

### Why is this safe for 65537?

When $E=65537$, the challenge ,$r$, can be selected from $0 \ge r < 65537-1$. We only select from $0 \ge r < (65536-1)$ as $65536$ is exactly two bytes. Having the challenge be two bytes makes it simple to generate and simple to pack the challenges. We lose a tiny amount of soundness but we get a lot of simplicity.

```golang
// split R into t numbers each consisting of vBytes bytes
Rs := make([]*bigmod.Nat, t)
for i := 0; i < t; i++ {
        Rs[i], err = new(bigmod.Nat).SetBytes(R[i*vBytes:(i+1)*vBytes], n)
        if err != nil {
	        return nil, err
        }
}
```
This code was likely written under the assumption that $E=65536$ and then was adapted to work with other values for $E$ without noticing the underlying assumptions.

## Fix

The short term fix is that we disallow any RSA public key exponent which is not 65537. All of the OpenID Providers we support use 65537 so this should not harm OpenPubkey functionality in anyway. This PR provides this short term fix.

Long term we should compute $t$ from the security parameter correctly. I've created the issue #230 to track this.

