### PR TITLE
Adds expiration policy

### DIFF
--- a/providers/expiration.go
+++ b/providers/expiration.go
@@ -1,0 +1,98 @@
+// Copyright 2025 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/openpubkey/openpubkey/oidc"
+)
+
+type ExpirationPolicy struct {
+	maxAge        time.Duration
+	checkMaxAge   bool
+	checkExpClaim bool
+}
+
+var ExpirationPolicies = struct {
+	OIDC            ExpirationPolicy // This uses the OpenID Connect expiration claim
+	MAX_AGE_24HOURS ExpirationPolicy // This replaces the OpenID Connect expiration claim with OpenPubkey 24 expiration
+	MAX_AGE_48HOURS ExpirationPolicy
+	MAX_AGE_1WEEK   ExpirationPolicy
+	NEVER_EXPIRE    ExpirationPolicy // ID Token will never expire until the OpenID Provider rotates the ID Token
+}{
+	OIDC:            ExpirationPolicy{maxAge: 0, checkMaxAge: false, checkExpClaim: true},
+	MAX_AGE_24HOURS: ExpirationPolicy{maxAge: 24 * time.Hour, checkMaxAge: true, checkExpClaim: false},
+	MAX_AGE_48HOURS: ExpirationPolicy{maxAge: 2 * 24 * time.Hour, checkMaxAge: true, checkExpClaim: false},
+	MAX_AGE_1WEEK:   ExpirationPolicy{maxAge: 7 * 24 * time.Hour, checkMaxAge: true, checkExpClaim: false},
+	NEVER_EXPIRE:    ExpirationPolicy{maxAge: 0, checkMaxAge: false, checkExpClaim: false},
+}
+
+func (ep ExpirationPolicy) CheckExpiration(claims oidc.OidcClaims) error {
+	if ep.checkExpClaim {
+		err := verifyNotExpired(claims.Expiration)
+		if err != nil {
+			return err
+		}
+	}
+	if ep.checkMaxAge {
+		err := checkMaxAge(claims.IssuedAt, int64(ep.maxAge.Seconds()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyNotExpired(expiration int64) error {
+	if expiration == 0 {
+		return fmt.Errorf("missing expiration claim")
+	}
+	if expiration < 0 {
+		return fmt.Errorf("expiration must be must be greater than zero (issuedAt = %v)", expiration)
+	}
+
+	// JWT expiration is "Seconds Since the Epoch"
+	// RFC-7519 -Section 2 https://www.rfc-editor.org/rfc/rfc7519#section-2
+	expirationTime := time.Unix(expiration, 0)
+	if !time.Now().Before(expirationTime) {
+		return fmt.Errorf("the ID token has expired (exp = %v)", expiration)
+	}
+	return nil
+}
+
+func checkMaxAge(issuedAt int64, maxAge int64) error {
+	if issuedAt == 0 {
+		return fmt.Errorf("missing issuedAt claim")
+	}
+	if issuedAt < 0 {
+		return fmt.Errorf("issuedAt must be must be greater than zero (issuedAt = %v)", issuedAt)
+	}
+	if !(maxAge > 0) {
+		return fmt.Errorf("maxAge configuration must be greater than zero (maxAge = %v)", maxAge)
+	}
+	// Ensure we throw an error is something goes wrong and we get parameters so large they overflow
+	if (issuedAt + maxAge) < issuedAt {
+		return fmt.Errorf("invalid values (issuedAt = %v, maxAge = %v)", issuedAt, maxAge)
+	}
+	expirationTime := time.Unix(issuedAt+maxAge, 0)
+	if !time.Now().Before(expirationTime) {
+		return fmt.Errorf("the PK token has expired based on maxAge (issuedAt = %v, maxAge = %v, expiratedAt = %v)", issuedAt, maxAge, expirationTime)
+	}
+	return nil
+}

--- a/providers/expirations_test.go
+++ b/providers/expirations_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/openpubkey/openpubkey/oidc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpirationPolicy(t *testing.T) {
+	claims := oidc.OidcClaims{
+		Expiration: time.Now().Add(1 * time.Hour).Unix(),
+		IssuedAt:   time.Now().Add(-1 * time.Hour).Unix(),
+	}
+	err := ExpirationPolicies.OIDC.CheckExpiration(claims)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_24HOURS.CheckExpiration(claims)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_48HOURS.CheckExpiration(claims)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_1WEEK.CheckExpiration(claims)
+	require.NoError(t, err)
+	err = ExpirationPolicies.NEVER_EXPIRE.CheckExpiration(claims)
+	require.NoError(t, err)
+
+	claimsOidcExpired := oidc.OidcClaims{
+		Expiration: time.Now().Add(-1 * time.Hour).Unix(),
+		IssuedAt:   time.Now().Add(-2 * time.Hour).Unix(),
+	}
+	err = ExpirationPolicies.OIDC.CheckExpiration(claimsOidcExpired)
+	require.ErrorContains(t, err, "the ID token has expired")
+	err = ExpirationPolicies.MAX_AGE_24HOURS.CheckExpiration(claims)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_48HOURS.CheckExpiration(claims)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_1WEEK.CheckExpiration(claims)
+	require.NoError(t, err)
+	err = ExpirationPolicies.NEVER_EXPIRE.CheckExpiration(claims)
+	require.NoError(t, err)
+
+	claimsMaxAge1Day := oidc.OidcClaims{
+		Expiration: time.Now().Add(1 * time.Hour).Unix(),
+		IssuedAt:   time.Now().Add(-25 * time.Hour).Unix(),
+	}
+	err = ExpirationPolicies.OIDC.CheckExpiration(claimsMaxAge1Day)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_24HOURS.CheckExpiration(claimsMaxAge1Day)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.MAX_AGE_48HOURS.CheckExpiration(claimsMaxAge1Day)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_1WEEK.CheckExpiration(claimsMaxAge1Day)
+	require.NoError(t, err)
+	err = ExpirationPolicies.NEVER_EXPIRE.CheckExpiration(claimsMaxAge1Day)
+	require.NoError(t, err)
+
+	claimsMaxAge2Day := oidc.OidcClaims{
+		Expiration: time.Now().Add(1 * time.Hour).Unix(),
+		IssuedAt:   time.Now().Add(-3 * 24 * time.Hour).Unix(),
+	}
+	err = ExpirationPolicies.OIDC.CheckExpiration(claimsMaxAge1Day)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_24HOURS.CheckExpiration(claimsMaxAge2Day)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.MAX_AGE_48HOURS.CheckExpiration(claimsMaxAge2Day)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.MAX_AGE_1WEEK.CheckExpiration(claimsMaxAge2Day)
+	require.NoError(t, err)
+	err = ExpirationPolicies.NEVER_EXPIRE.CheckExpiration(claimsMaxAge2Day)
+	require.NoError(t, err)
+
+	claimsMaxAge1Week := oidc.OidcClaims{
+		Expiration: time.Now().Add(1 * time.Hour).Unix(),
+		IssuedAt:   time.Now().Add(-8 * 24 * time.Hour).Unix(),
+	}
+	err = ExpirationPolicies.OIDC.CheckExpiration(claimsMaxAge1Week)
+	require.NoError(t, err)
+	err = ExpirationPolicies.MAX_AGE_24HOURS.CheckExpiration(claimsMaxAge1Week)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.MAX_AGE_48HOURS.CheckExpiration(claimsMaxAge1Week)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.MAX_AGE_1WEEK.CheckExpiration(claimsMaxAge1Week)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.NEVER_EXPIRE.CheckExpiration(claimsMaxAge1Week)
+	require.NoError(t, err)
+
+	claimsBothExpire := oidc.OidcClaims{
+		Expiration: time.Now().Add(-10 * time.Hour).Unix(),
+		IssuedAt:   time.Now().Add(-8000 * 24 * time.Hour).Unix(),
+	}
+	err = ExpirationPolicies.OIDC.CheckExpiration(claimsBothExpire)
+	require.ErrorContains(t, err, "the ID token has expired")
+	err = ExpirationPolicies.MAX_AGE_24HOURS.CheckExpiration(claimsBothExpire)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.MAX_AGE_48HOURS.CheckExpiration(claimsBothExpire)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.MAX_AGE_1WEEK.CheckExpiration(claimsBothExpire)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+	err = ExpirationPolicies.NEVER_EXPIRE.CheckExpiration(claimsBothExpire)
+	require.NoError(t, err)
+}
+
+func TestIDTokenExpiration(t *testing.T) {
+	oneHourFromNow := time.Now().Add(1 * time.Hour)
+	err := verifyNotExpired(oneHourFromNow.Unix())
+	require.NoError(t, err)
+
+	oneHourAgo := time.Now().Add(-1 * time.Hour)
+	err = verifyNotExpired(oneHourAgo.Unix())
+	require.ErrorContains(t, err, "the ID token has expired")
+
+	err = verifyNotExpired(0)
+	require.ErrorContains(t, err, "missing expiration claim")
+
+	err = verifyNotExpired(-1)
+	require.ErrorContains(t, err, "expiration must be must be greater than zero")
+}
+
+func TestMaxAgeExpiration(t *testing.T) {
+	twoHoursAgo := time.Now().Add(-2 * time.Hour)
+	maxAgeThreeHours := int64(3 * 60 * 60) // 3 hours in seconds
+	err := checkMaxAge(twoHoursAgo.Unix(), maxAgeThreeHours)
+	require.NoError(t, err)
+
+	maxAgeOneHour := int64(1 * 60 * 60) // 3 hours in seconds
+	err = checkMaxAge(twoHoursAgo.Unix(), maxAgeOneHour)
+	require.ErrorContains(t, err, "the PK token has expired based on maxAge")
+
+	err = checkMaxAge(0, 1)
+	require.ErrorContains(t, err, "missing issuedAt claim")
+
+	err = checkMaxAge(-1, 1)
+	require.ErrorContains(t, err, "issuedAt must be must be greater than zero")
+
+	err = checkMaxAge(twoHoursAgo.Unix(), 0)
+	require.ErrorContains(t, err, "maxAge configuration must be greater than zero")
+
+	err = checkMaxAge(math.MaxInt64, math.MaxInt64)
+	require.ErrorContains(t, err, "invalid values")
+}

--- a/providers/github_actions.go
+++ b/providers/github_actions.go
@@ -167,6 +167,6 @@ func (g *GithubOp) Issuer() string {
 }
 
 func (g *GithubOp) VerifyIDToken(ctx context.Context, idt []byte, cic *clientinstance.Claims) error {
-	vp := NewProviderVerifier(g.issuer, ProviderVerifierOpts{CommitType: CommitTypesEnum.AUD_CLAIM, GQOnly: true, SkipClientIDCheck: true})
+	vp := NewProviderVerifier(g.issuer, ProviderVerifierOpts{CommitType: CommitTypesEnum.AUD_CLAIM, GQOnly: true, SkipClientIDCheck: true, ExpirationPolicy: &ExpirationPolicies.OIDC})
 	return vp.VerifyIDToken(ctx, idt, cic)
 }

--- a/providers/gitlab_ci.go
+++ b/providers/gitlab_ci.go
@@ -102,7 +102,7 @@ func (g *GitlabOp) Issuer() string {
 
 func (g *GitlabOp) VerifyIDToken(ctx context.Context, idt []byte, cic *clientinstance.Claims) error {
 	vp := NewProviderVerifier(g.issuer,
-		ProviderVerifierOpts{CommitType: CommitTypesEnum.GQ_BOUND, GQOnly: true, SkipClientIDCheck: true},
+		ProviderVerifierOpts{CommitType: CommitTypesEnum.GQ_BOUND, GQOnly: true, SkipClientIDCheck: true, ExpirationPolicy: &ExpirationPolicies.OIDC},
 	)
 	return vp.VerifyIDToken(ctx, idt, cic)
 }

--- a/providers/mocks/idtoken.go
+++ b/providers/mocks/idtoken.go
@@ -97,6 +97,7 @@ func (t *IDTokenTemplate) IssueToken() (*oidc.Tokens, error) {
 		"aud": t.Aud,
 		"iss": t.Issuer,
 		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(2 * time.Hour).Unix(),
 	}
 
 	if !t.NoNonce {

--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -268,7 +268,17 @@ func (s *StandardOp) Issuer() string {
 }
 
 func (s *StandardOp) VerifyIDToken(ctx context.Context, idt []byte, cic *clientinstance.Claims) error {
-	vp := NewProviderVerifier(s.issuer, ProviderVerifierOpts{CommitType: CommitTypesEnum.NONCE_CLAIM, ClientID: s.ClientID, DiscoverPublicKey: &s.publicKeyFinder})
+	vp := NewProviderVerifier(
+		s.issuer,
+		ProviderVerifierOpts{
+			CommitType:        CommitTypesEnum.NONCE_CLAIM,
+			ClientID:          s.ClientID,
+			DiscoverPublicKey: &s.publicKeyFinder,
+			// For user access we override the ID Token expiration claim
+			// and instead have tokens expire after 24 hours so that
+			// users don't have log back in every hour.
+			ExpirationPolicy: &ExpirationPolicies.MAX_AGE_24HOURS,
+		})
 	return vp.VerifyIDToken(ctx, idt, cic)
 }
 


### PR DESCRIPTION
This enables PK Tokens to expire and allows parties to configure the policy under which PK Tokens expire.

It allows providers to specify the expiration policy they want to enforce. It supports five policies:
- The base OpenID Connect policy where if the current time is later than the `exp` the PK Token is expired
- Three policies based on age of the `iat` (IssuedAt) claim. If PK Token is older than 1 day, 2 days, 1 week.
- Never expire

Fixes #232 
Fixes #187

This feature was inspired by the bug discovered while talking with @SaahilNotSahil from https://github.com/devlup-labs/spok

## Tests

This PR creates unittests. Additionally a manual test for the web example was run on against Azure.