### PR TITLE
Renames opk-ssh to opkssh

### DIFF
--- a/opkssh/README.md
+++ b/opkssh/README.md
@@ -1,4 +1,4 @@
-# opk-ssh
+# opkssh
 OpenPubKey SSH
 
 For more documentation see: https://github.com/openpubkey/openpubkey/pull/43
@@ -13,7 +13,7 @@ GOARCH=amd64 GOOS=linux go build
 ```
 2. Copy the built binary up to the SSH server you want to configure
 ```bash
-scp opk-ssh ${USER}@${HOSTNAME}:~
+scp opkssh ${USER}@${HOSTNAME}:~
 ```
 3. SSH onto the server 
 ```bash
@@ -22,22 +22,22 @@ ssh ${HOSTNAME}
 4. Create our file directory on the server and move the executable there:
 ```bash
 sudo mkdir /etc/opk
-sudo mv ~/opk-ssh /etc/opk
-sudo chown root /etc/opk/opk-ssh
-sudo chmod 700 /etc/opk/opk-ssh 
+sudo mv ~/opkssh /etc/opk
+sudo chown root /etc/opk/opkssh
+sudo chmod 700 /etc/opk/opkssh 
 ```
 5. Create our policy on the server at /etc/opk/policy.yml. If you do not have root access,
 create a new policy.yml file in at ~/policy.yml and use that instead. You
-will also need to have a opk-ssh binary available to use in the same directory.
+will also need to have a opkssh binary available to use in the same directory.
 ```bash
 sudo touch /etc/opk/policy.yml
 sudo chown root /etc/opk/policy.yml
 sudo chmod 600 /etc/opk/policy.yml
-sudo /etc/opk/opk-ssh add {EMAIL} {USER}
+sudo /etc/opk/opkssh add {EMAIL} {USER}
 ```
 6. Add the folowing lines to the sshd file `/etc/ssh/sshd_config`
 ```bash
-AuthorizedKeysCommand /etc/opk/opk-ssh verify %u %k %t
+AuthorizedKeysCommand /etc/opk/opkssh verify %u %k %t
 AuthorizedKeysCommandUser root
 ```
 7. Restart sshd
@@ -46,13 +46,13 @@ sudo systemctl restart sshd
 ```
 
 ## Connecting via the Client
-1. Build the client cli from the root of the opk-ssh repo:
+1. Build the client cli from the root of the opkssh repo:
 ```bash
 go build
 ```
 2. Login
 ```bash
-./opk-ssh login
+./opkssh login
 ```
 3. Get the IP of the server, (this is a neat trick for our AL2 bzero linux instances):
 ```bash

--- a/opkssh/commands/add.go
+++ b/opkssh/commands/add.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openpubkey/openpubkey/opkssh/policy"
 )
 
-// AddCmd provides functionality to read and update the opk-ssh policy file
+// AddCmd provides functionality to read and update the opkssh policy file
 type AddCmd struct {
 	PolicyFileLoader *policy.FileLoader
 
@@ -35,7 +35,7 @@ type AddCmd struct {
 	Username string
 }
 
-// LoadPolicy reads the opk-ssh policy at the policy.SystemDefaultPolicyPath. If
+// LoadPolicy reads the opkssh policy at the policy.SystemDefaultPolicyPath. If
 // there is a permission error when reading this file, then the user's local
 // policy file (defined as ~/.opk/policy.yml where ~ maps to AddCmd.Username's
 // home directory) is read instead.

--- a/opkssh/commands/verify.go
+++ b/opkssh/commands/verify.go
@@ -73,8 +73,8 @@ func (v *VerifyCmd) Verify(ctx context.Context, username string, pubkey string, 
 	}
 }
 
-// OpkPolicyEnforcerAsAuthFunc returns an opk-ssh policy.Enforcer that can be
-// used in the opk-ssh verify command.
+// OpkPolicyEnforcerAsAuthFunc returns an opkssh policy.Enforcer that can be
+// used in the opkssh verify command.
 func OpkPolicyEnforcerAsAuthFunc(username string) AuthFunc {
 	policyEnforcer := &policy.Enforcer{
 		PolicyLoader: &policy.MultiFileLoader{

--- a/opkssh/internal/projectpath/projectpath.go
+++ b/opkssh/internal/projectpath/projectpath.go
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package projectpath is used internally by the integration tests to get the
-// root folder of the opk-ssh project
+// root folder of the opkssh project
 package projectpath
 
 import (
@@ -27,6 +27,6 @@ import (
 var (
 	_, b, _, _ = runtime.Caller(0)
 
-	// Root is the root folder of the opk-ssh project
+	// Root is the root folder of the opkssh project
 	Root = filepath.Join(filepath.Dir(b), "../../..")
 )

--- a/opkssh/main.go
+++ b/opkssh/main.go
@@ -119,7 +119,7 @@ func run() int {
 
 		// These arguments are sent by sshd and dictated by the pattern as defined in the sshd config
 		// Example line in sshd config:
-		// 		AuthorizedKeysCommand /etc/opk/opk-ssh verify %u %k %t
+		// 		AuthorizedKeysCommand /etc/opk/opkssh verify %u %k %t
 		//
 		//	%u The desired user being assumed on the target (aka requested principal).
 		//	%k The base64-encoded public key for authentication.
@@ -149,7 +149,7 @@ func run() int {
 		// script to inject user entries into the policy file
 		//
 		// Example line to add a user:
-		// 		./opk-ssh add %e %p
+		// 		./opkssh add %e %p
 		//
 		//  %e The email of the user to be added to the policy file.
 		//	%p The desired principal being assumed on the target (aka requested principal).

--- a/opkssh/policy/enforcer.go
+++ b/opkssh/policy/enforcer.go
@@ -24,13 +24,13 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// Enforcer evaluates opk-ssh policy to determine if the desired principal is
+// Enforcer evaluates opkssh policy to determine if the desired principal is
 // permitted
 type Enforcer struct {
 	PolicyLoader Loader
 }
 
-// CheckPolicy loads the opk-ssh policy and checks to see if there is a policy
+// CheckPolicy loads the opkssh policy and checks to see if there is a policy
 // permitting access to principalDesired for the user identified by the PKT's
 // email claim. Returns nil if access is granted. Otherwise, an error is
 // returned.

--- a/opkssh/policy/fileloader.go
+++ b/opkssh/policy/fileloader.go
@@ -26,11 +26,11 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// SystemDefaultPolicyPath is the default filepath where opk-ssh policy is
+// SystemDefaultPolicyPath is the default filepath where opkssh policy is
 // defined
 const SystemDefaultPolicyPath = "/etc/opk/policy.yml"
 
-// ModeOnlyOwner is the expected permission bits that should be set for opk-ssh
+// ModeOnlyOwner is the expected permission bits that should be set for opkssh
 // policy files. This mode means that only the owner of the file can read/write
 const ModeOnlyOwner = fs.FileMode(0600)
 
@@ -49,7 +49,7 @@ func NewOsUserLookup() UserLookup {
 }
 func (OsUserLookup) Lookup(username string) (*user.User, error) { return user.Lookup(username) }
 
-// FileLoader contains methods to read/write the opk-ssh policy file from/to an
+// FileLoader contains methods to read/write the opkssh policy file from/to an
 // arbitrary filesystem. All methods that read policy from the filesystem fail
 // and return an error immediately if the permission bits are invalid.
 type FileLoader struct {
@@ -57,7 +57,7 @@ type FileLoader struct {
 	UserLookup UserLookup
 }
 
-// NewFileLoader returns an opk-ssh policy loader that uses the os library to
+// NewFileLoader returns an opkssh policy loader that uses the os library to
 // read/write policy from/to the filesystem.
 func NewFileLoader() *FileLoader {
 	return &FileLoader{
@@ -99,7 +99,7 @@ func (l *FileLoader) LoadPolicyAtPath(path string) (*Policy, error) {
 	return policy, nil
 }
 
-// LoadSystemDefaultPolicy reads the opk-ssh policy at SystemDefaultPolicyPath.
+// LoadSystemDefaultPolicy reads the opkssh policy at SystemDefaultPolicyPath.
 // An error is returned if the file cannot be read or if the permissions bits
 // are not correct.
 func (l *FileLoader) LoadSystemDefaultPolicy() (*Policy, error) {
@@ -111,7 +111,7 @@ func (l *FileLoader) LoadSystemDefaultPolicy() (*Policy, error) {
 	return policy, nil
 }
 
-// LoadUserPolicy reads the user's opk-ssh policy at ~/.opk/policy.yml (where ~
+// LoadUserPolicy reads the user's opkssh policy at ~/.opk/policy.yml (where ~
 // maps to username's home directory) and returns the filepath read. An error is
 // returned if the file cannot be read, if the permission bits are not correct,
 // or if there is no user with username or has no home directory.

--- a/opkssh/policy/policy.go
+++ b/opkssh/policy/policy.go
@@ -23,7 +23,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// User is an opk-ssh policy user entry
+// User is an opkssh policy user entry
 type User struct {
 	// Email is the user's email. It is the expected value used when comparing
 	// against an id_token's email claim
@@ -33,7 +33,7 @@ type User struct {
 	// Sub        string   `yaml:"sub,omitempty"`
 }
 
-// Policy represents an opk-ssh policy
+// Policy represents an opkssh policy
 type Policy struct {
 	// Users is a list of all user entries in the policy
 	Users []User `yaml:"users"`
@@ -102,9 +102,9 @@ func (p *Policy) ToYAML() ([]byte, error) {
 }
 
 // Source declares the minimal interface to describe the source of a fetched
-// opk-ssh policy (i.e. where the policy is retrieved from)
+// opkssh policy (i.e. where the policy is retrieved from)
 type Source interface {
-	// Source returns a string describing the source of an opk-ssh policy. The
+	// Source returns a string describing the source of an opkssh policy. The
 	// returned value is empty if there is no information about its source
 	Source() string
 }
@@ -117,10 +117,10 @@ type EmptySource struct{}
 
 func (EmptySource) Source() string { return "" }
 
-// Loader declares the minimal interface to retrieve an opk-ssh policy from an
+// Loader declares the minimal interface to retrieve an opkssh policy from an
 // arbitrary source
 type Loader interface {
-	// Load fetches an opk-ssh policy and returns information describing its
+	// Load fetches an opkssh policy and returns information describing its
 	// source. If an error occurs, all return values are nil except the error
 	// value
 	Load() (*Policy, Source, error)

--- a/opkssh/policy/policy_test.go
+++ b/opkssh/policy/policy_test.go
@@ -26,7 +26,7 @@ import (
 func TestAddAllowedPrincipal(t *testing.T) {
 	t.Parallel()
 
-	// Test adding an allowed principal to an opk-ssh policy
+	// Test adding an allowed principal to an opkssh policy
 	tests := []struct {
 		name           string
 		principal      string

--- a/opkssh/test/integration/add_test.go
+++ b/opkssh/test/integration/add_test.go
@@ -53,7 +53,7 @@ func executeCommandAsUser(t *testing.T, container testcontainers.Container, cmd 
 }
 
 func TestAdd(t *testing.T) {
-	// Test adding an allowed principal to an opk-ssh policy
+	// Test adding an allowed principal to an opkssh policy
 
 	tests := []struct {
 		name             string
@@ -65,7 +65,7 @@ func TestAdd(t *testing.T) {
 	}{
 		{
 			name:             "sudoer user can update root policy",
-			binaryPath:       "/etc/opk/opk-ssh",
+			binaryPath:       "/etc/opk/opkssh",
 			useSudo:          true,
 			cmdUser:          SudoerUser,
 			desiredPrincipal: SudoerUser,
@@ -73,7 +73,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name:             "sudoer user can update root policy with principal != self",
-			binaryPath:       "/etc/opk/opk-ssh",
+			binaryPath:       "/etc/opk/opkssh",
 			useSudo:          true,
 			cmdUser:          SudoerUser,
 			desiredPrincipal: UnprivUser,
@@ -81,7 +81,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name:             "unprivileged user can update their user policy",
-			binaryPath:       "/home/test2/.opk/opk-ssh",
+			binaryPath:       "/home/test2/.opk/opkssh",
 			useSudo:          false,
 			cmdUser:          UnprivUser,
 			desiredPrincipal: UnprivUser,
@@ -89,7 +89,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name:             "unprivileged user cannot add principal != self",
-			binaryPath:       "/home/test2/.opk/opk-ssh",
+			binaryPath:       "/home/test2/.opk/opkssh",
 			useSudo:          false,
 			cmdUser:          UnprivUser,
 			desiredPrincipal: SudoerUser,

--- a/opkssh/test/integration/integration.go
+++ b/opkssh/test/integration/integration.go
@@ -18,7 +18,7 @@
 
 // Package integration contains integration tests.
 //
-// These tests test opk-ssh e2e using external dependencies.
+// These tests test opkssh e2e using external dependencies.
 package integration
 
 import (
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	// LoginCallbackServerTimeout is the amount of time to wait for the opk-ssh
+	// LoginCallbackServerTimeout is the amount of time to wait for the opkssh
 	// login callback server to startup
 	LoginCallbackServerTimeout = 5 * time.Second
 )

--- a/opkssh/test/integration/ssh_server/debian_opkssh.Dockerfile
+++ b/opkssh/test/integration/ssh_server/debian_opkssh.Dockerfile
@@ -47,7 +47,7 @@ RUN sed -i '/^AuthorizedKeysCommandUser /s/^/#/' /etc/ssh/sshd_config
 
 # Add our AuthorizedKeysCommand line so that the opk verifier is called when
 # ssh-ing in
-RUN echo "AuthorizedKeysCommand /etc/opk/opk-ssh verify %u %k %t\nAuthorizedKeysCommandUser root" >> /etc/ssh/sshd_config
+RUN echo "AuthorizedKeysCommand /etc/opk/opkssh verify %u %k %t\nAuthorizedKeysCommandUser root" >> /etc/ssh/sshd_config
 
 # Expose SSH server so we can ssh in from the tests
 EXPOSE 22
@@ -62,24 +62,24 @@ RUN go mod download
 # Copy our repo
 COPY . ./
 
-# Build "opk-ssh" binary and write to the opk directory
+# Build "opkssh" binary and write to the opk directory
 ARG ISSUER_PORT="9998"
 # Configure the OpenIdProvider (GoogleOp) verifier code to use expected clientId
 # (web), clientSecret (secret), and issuer URL (http://oidc.local:9998/). Host
 # "oidc.local" should be mapped to the IP of the docker container running the
 # zitadel dynamic exampleop server (configure ExtraHosts when running this
 # container).
-RUN go build -v -o /etc/opk/opk-ssh -ldflags "-X main.issuer=http://oidc.local:${ISSUER_PORT}/ -X main.clientID=web -X main.clientSecret=secret" ./opkssh
-RUN chmod 700 /etc/opk/opk-ssh
+RUN go build -v -o /etc/opk/opkssh -ldflags "-X main.issuer=http://oidc.local:${ISSUER_PORT}/ -X main.clientID=web -X main.clientSecret=secret" ./opkssh
+RUN chmod 700 /etc/opk/opkssh
 
 # Copy binary to unprivileged user's home directory
-RUN cp /etc/opk/opk-ssh /home/test2/.opk/opk-ssh
-RUN chown test2:test2 /home/test2/.opk/opk-ssh
+RUN cp /etc/opk/opkssh /home/test2/.opk/opkssh
+RUN chown test2:test2 /home/test2/.opk/opkssh
 
 # Add integration test user as allowed email in policy (this directly tests
 # policy "add" command)
 ARG BOOTSTRAP_POLICY
-RUN if [ -n "$BOOTSTRAP_POLICY" ] ; then /etc/opk/opk-ssh add "test-user@zitadel.ch" "test" ; else echo "Will not init policy" ; fi
+RUN if [ -n "$BOOTSTRAP_POLICY" ] ; then /etc/opk/opkssh add "test-user@zitadel.ch" "test" ; else echo "Will not init policy" ; fi
 
 # Start SSH server on container startup
 CMD ["/usr/sbin/sshd", "-D"]

--- a/opkssh/test/integration/ssh_test.go
+++ b/opkssh/test/integration/ssh_test.go
@@ -59,7 +59,7 @@ const (
 
 	// networkName is the name of the Docker network that the test containers
 	// are connected to
-	networkName = "opk-ssh-integration-test-net"
+	networkName = "opkssh-integration-test-net"
 )
 
 // oidcHttpClientTransport wraps an existing http.RoundTripper and sets the
@@ -164,7 +164,7 @@ func createOpkSshSigner(t *testing.T, pubKey ssh.PublicKey, secKeyFilePath strin
 }
 
 // createZitadelOPKSshProvider creates an OPK SSH provider, the same one used by
-// opk-ssh, except the issuer has been configured to be the fake OIDC server
+// opkssh, except the issuer has been configured to be the fake OIDC server
 // running in a Docker container
 //
 // This function returns both an OPK SSH provider and an HTTP transport that has
@@ -209,7 +209,7 @@ func createZitadelOPKSshProvider(t *testing.T, oidcContainerMappedPort int, auth
 }
 
 // spawnTestContainers spawns a container running an example OIDC issuer and a
-// linux container configured with sshd and opk-ssh as the
+// linux container configured with sshd and opkssh as the
 // AuthorizedKeysCommand.
 //
 // Test cleanup functions are registered to cleanup the containers after the
@@ -258,7 +258,7 @@ func spawnTestContainers(t *testing.T) (oidcContainer *testprovider.ExampleOpCon
 		}
 	})
 
-	// Start linux container with opk-ssh installed and configured to verify
+	// Start linux container with opkssh installed and configured to verify
 	// incoming PK tokens against the OIDC issuer created above
 	issuerIp, err := oidcContainer.ContainerIP(TestCtx)
 	require.NoError(t, err)
@@ -274,7 +274,7 @@ func spawnTestContainers(t *testing.T) (oidcContainer *testprovider.ExampleOpCon
 		require.NoError(t, serverContainer.Terminate(TestCtx), "failed to terminate SSH container")
 	})
 
-	// Use backdoor (non-OPK) SSH client to dump opk-ssh logs if test fails
+	// Use backdoor (non-OPK) SSH client to dump opkssh logs if test fails
 	auth := goph.Password(serverContainer.Password)
 	nonOpkSshClient, err := goph.NewConn(&goph.Config{
 		User:     serverContainer.User,
@@ -287,7 +287,7 @@ func spawnTestContainers(t *testing.T) (oidcContainer *testprovider.ExampleOpCon
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if t.Failed() {
-			// Get opk-ssh error logs
+			// Get opkssh error logs
 			_, err := nonOpkSshClient.Run("sudo chmod 777 /var/log/openpubkey.log")
 			if assert.NoError(t, err) {
 				errorLog, err := nonOpkSshClient.Run("cat /var/log/openpubkey.log")
@@ -302,10 +302,10 @@ func spawnTestContainers(t *testing.T) (oidcContainer *testprovider.ExampleOpCon
 }
 
 func TestEndToEndSSH(t *testing.T) {
-	// Test opk-ssh e2e by performing an SSH connection to a linux container.
+	// Test opkssh e2e by performing an SSH connection to a linux container.
 	//
 	// Tests login, policy, and verify against an example OIDC server and
-	// container configured with opk-ssh in the "AuthorizedKeysCommand"
+	// container configured with opkssh in the "AuthorizedKeysCommand"
 	var err error
 
 	// Spawn test containers to run these tests
@@ -369,7 +369,7 @@ func TestEndToEndSSH(t *testing.T) {
 }
 
 func TestEndToEndSSHAsUnprivilegedUser(t *testing.T) {
-	// Test usecase of unprivileged user using opk-ssh e2e by performing an SSH
+	// Test usecase of unprivileged user using opkssh e2e by performing an SSH
 	// connection to a linux container.
 	//
 	// This user has policy access via their user policy--not the root policy
@@ -382,7 +382,7 @@ func TestEndToEndSSHAsUnprivilegedUser(t *testing.T) {
 	zitadelOp, customTransport := createZitadelOPKSshProvider(t, oidcContainer.Port, authCallbackRedirectPort)
 
 	// Give integration test user access to test2 via user policy
-	code, _ := executeCommandAsUser(t, serverContainer.Container, []string{"/bin/bash", "-c", "/home/test2/.opk/opk-ssh add \"test-user@zitadel.ch\" \"test2\""}, "test2")
+	code, _ := executeCommandAsUser(t, serverContainer.Container, []string{"/bin/bash", "-c", "/home/test2/.opk/opkssh add \"test-user@zitadel.ch\" \"test2\""}, "test2")
 	require.Equal(t, 0, code, "failed to update user policy")
 
 	// Call login
@@ -457,7 +457,7 @@ func updateIdTokenLifetime(t *testing.T, oidcContainerMappedPort int, duration s
 }
 
 func TestEndToEndSSHWithRefresh(t *testing.T) {
-	// Test refresh flow of opk-ssh e2e by first attempting to SSH with an
+	// Test refresh flow of opkssh e2e by first attempting to SSH with an
 	// expired id_token (and expect a failure). Then, let the background refresh
 	// process get a new unexpired id_token, and then attempt a successful SSH
 	// connection.


### PR DESCRIPTION
I don't want anyone to have to type the hyphen anymore or need to remember that a hyphen is required. This change reduces the number of keystrokes needed by 14%