### PR TITLE
Update google and azure clientIDs

### DIFF
--- a/opkssh/commands/install.go
+++ b/opkssh/commands/install.go
@@ -36,8 +36,8 @@ func Install() error {
 	installScript := `
 #!/bin/sh
 
-PROVIDER_GOOGLE="https://accounts.google.com 992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com 24h"
-PROVIDER_MICROSOFT="https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 bd345b9c-6902-400d-9e18-45abdf0f698f 24h"
+PROVIDER_GOOGLE="https://accounts.google.com 411517154569-7f10v0ftgp5elms1q8fm7avtp33t7i7n.apps.googleusercontent.com 24h"
+PROVIDER_MICROSOFT="https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h"
 
 sudo mkdir -p /etc/opk
 sudo touch /etc/opk/auth_id

--- a/opkssh/docs/config.md
+++ b/opkssh/docs/config.md
@@ -26,8 +26,8 @@ The file lives at `/etc/opk/providers` and the default values are:
 
 ```
 # Issuer Client-ID expiration-policy 
-https://accounts.google.com 992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com 24h
-https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 bd345b9c-6902-400d-9e18-45abdf0f698f 24h
+https://accounts.google.com 411517154569-7f10v0ftgp5elms1q8fm7avtp33t7i7n.apps.googleusercontent.com 24h
+https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h
 ```
 
 This PR does not support workload OPs like github-actions or gitlab-ci but the intent is for these to use a wildcard `*` for the Client ID (`aud`).
@@ -51,7 +51,7 @@ This is a server wide policy file.
 alice alice@example.com https://accounts.google.com
 guest alice@example.com https://accounts.google.com 
 root alice@example.com https://accounts.google.com 
-dev bob@microsoft.com https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 bd345b9c-6902-400d-9e18-45abdf0f698f
+dev bob@microsoft.com https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01
 ```
 
 `sudo /etc/opk/opkssh add {USER} {EMAIL} {ISSUER}`
@@ -116,8 +116,8 @@ sed -i '/^AuthorizedKeysCommandUser /s/^/#/' /etc/ssh/sshd_config
 echo "AuthorizedKeysCommand /etc/opk/opkssh verify %u %k %t\nAuthorizedKeysCommandUser root" >> /etc/ssh/sshd_config
 sudo systemctl restart ssh
 
-echo "https://accounts.google.com 992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com 24h" >> /etc/opk/providers
-echo "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 bd345b9c-6902-400d-9e18-45abdf0f698f 24h" >> /etc/opk/providers
+echo "https://accounts.google.com 411517154569-7f10v0ftgp5elms1q8fm7avtp33t7i7n.apps.googleusercontent.com 24h" >> /etc/opk/providers
+echo "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h" >> /etc/opk/providers
 ```
 
 Then for each supported user:

--- a/opkssh/policy/files/table_test.go
+++ b/opkssh/policy/files/table_test.go
@@ -52,11 +52,11 @@ func TestToTable(t *testing.T) {
 		{
 			name: "realistic input",
 			input: `# Issuer Client-ID expiration-policy
-https://accounts.google.com 992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com 24h
-https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 bd345b9c-6902-400d-9e18-45abdf0f698f 24h`,
+https://accounts.google.com 411517154569-7f10v0ftgp5elms1q8fm7avtp33t7i7n.apps.googleusercontent.com 24h
+https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h`,
 			output: [][]string{
-				{"https://accounts.google.com", "992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com", "24h"},
-				{"https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0", "bd345b9c-6902-400d-9e18-45abdf0f698f", "24h"},
+				{"https://accounts.google.com", "411517154569-7f10v0ftgp5elms1q8fm7avtp33t7i7n.apps.googleusercontent.com", "24h"},
+				{"https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0", "096ce0a3-5e72-4da8-9c86-12924b294a01", "24h"},
 			},
 		},
 	}

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -72,7 +72,7 @@ func GetDefaultAzureOpOptions() *AzureOptions {
 	defaultTenantID := "9188040d-6c67-4c5b-b112-36a304b66dad"
 	return &AzureOptions{
 		Issuer:   azureIssuer(defaultTenantID),
-		ClientID: "bd345b9c-6902-400d-9e18-45abdf0f698f", // TODO: replace with a better client ID
+		ClientID: "096ce0a3-5e72-4da8-9c86-12924b294a01",
 		// Scopes:   []string{"openid profile email"},
 		Scopes: []string{"openid profile email offline_access"}, // offline_access is required for refresh tokens
 		RedirectURIs: []string{

--- a/providers/google.go
+++ b/providers/google.go
@@ -69,10 +69,10 @@ type GoogleOptions struct {
 func GetDefaultGoogleOpOptions() *GoogleOptions {
 	return &GoogleOptions{
 		Issuer:   googleIssuer,
-		ClientID: "992028499768-ce9juclb3vvckh23r83fjkmvf1lvjq18.apps.googleusercontent.com",
+		ClientID: "411517154569-7f10v0ftgp5elms1q8fm7avtp33t7i7n.apps.googleusercontent.com",
 		// The clientSecret was intentionally checked in. It holds no power. Do not report as a security issue
 		// Google requires a ClientSecret even if this a public OIDC App
-		ClientSecret: "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", // The client secret is a public value
+		ClientSecret: "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", // The client secret is a public value
 		Scopes:       []string{"openid profile email"},
 		RedirectURIs: []string{
 			"http://localhost:3000/login-callback",


### PR DESCRIPTION
Previously I was using test client IDs. This replaces these with client IDs that I don't expect to change in the coming decade.

Fixes https://github.com/openpubkey/openpubkey/issues/259 

- [x] Test this works with Google
- [x] Test this works with Azure