### PR TITLE
Creates opkssh binary release github action workflow

### DIFF
--- a/.github/workflows/release-opkssh.yml
+++ b/.github/workflows/release-opkssh.yml
@@ -1,0 +1,44 @@
+name: Build and Upload Release
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build_and_upload:
+    name: Build and Upload Binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+
+      - name: Extract version from tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Build binaries
+        run: |
+          GOOS=linux GOARCH=amd64 go build -ldflags="-X main.Version=${VERSION}" -o opkssh-linux-amd64 ./opkssh 
+          GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.Version=${VERSION}" -o opkssh-osx-amd64 ./opkssh 
+          GOOS=windows GOARCH=amd64 go build -ldflags="-X main.Version=${VERSION}" -o opkssh-windows-amd64.exe ./opkssh
+
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            opkssh-linux-amd64
+            opkssh-osx-amd64
+            opkssh-windows-amd64.exe
+          tag_name: ${{ github.event.release.tag_name }}
+          name: Release ${{ github.event.release.tag_name }}
+          body: ${{ github.event.release.body }}
+          draft: true
+          prerelease: false

--- a/opkssh/main.go
+++ b/opkssh/main.go
@@ -42,6 +42,7 @@ var (
 
 	// These can be overridden at build time using ldflags. For example:
 	// go build -v -o /etc/opk/opkssh -ldflags "-X main.issuer=http://oidc.local:${ISSUER_PORT}/ -X main.clientID=web -X main.clientSecret=secret"
+	Version      = "unversioned"
 	issuer       = ""
 	clientID     = ""
 	clientSecret = ""
@@ -252,6 +253,8 @@ func run() int {
 			fmt.Println("successfully installed opkssh")
 			return 0
 		}
+	case "--version", "-v":
+		fmt.Println(Version)
 	default:
 		fmt.Println("ERROR! Unrecognized command:", command)
 		return 1


### PR DESCRIPTION
This PR does two things:

It creates binary releases of OPKSSH 

It uses the existing release drafter to inject a version into the opkssh binary to support `opkssh --version` 
Fixes https://github.com/openpubkey/openpubkey/issues/252