### PR TITLE
opkssh add creates `~/.opk/auth_id` if it doesn't exist yet

### DIFF
--- a/opkssh/commands/add.go
+++ b/opkssh/commands/add.go
@@ -64,28 +64,49 @@ func (a *AddCmd) LoadPolicy() (*policy.Policy, string, error) {
 	return systemPolicy, policy.SystemDefaultPolicyPath, nil
 }
 
+// GetPolicyPath returns the path to the policy file that the current command
+// will write to.
+func (a *AddCmd) GetPolicyPath(principal string, userEmail string, issuer string) (string, error) {
+	// Try to read system policy first
+	_, err := a.PolicyFileLoader.LoadSystemDefaultPolicy()
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			// If current process doesn't have permission, try reading the user
+			// policy file.
+			policyFilePath, err := a.PolicyFileLoader.UserPolicyPath(a.Username)
+			if err != nil {
+				return "", err
+			}
+			return policyFilePath, nil
+		} else {
+			// Non-permission error (e.g. system policy file missing or invalid
+			// permission bits set). Return error
+			return "", err
+		}
+	}
+	return policy.SystemDefaultPolicyPath, nil
+}
+
 // Add adds a new allowed principal to the user whose email is equal to
 // userEmail. The current policy file is read and modified.
 //
 // If successful, returns the policy filepath updated. Otherwise, returns a
 // non-nil error
 func (a *AddCmd) Add(principal string, userEmail string, issuer string) (string, error) {
+	policyPath, err := a.GetPolicyPath(principal, userEmail, issuer)
+	if err != nil {
+		return "", fmt.Errorf("failed to load current policy: %w", err)
+	}
+	err = a.PolicyFileLoader.CreateIfDoesNotExist(policyPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create policy file: %w", err)
+	}
+
 	// Read current policy
 	currentPolicy, policyFilePath, err := a.LoadPolicy()
 	if err != nil {
 		return "", fmt.Errorf("failed to load current policy: %w", err)
 	}
-	// exists, err := afero.Exists(l.Fs, path)
-	// if err != nil {
-	// 	return err
-	// }
-	// if !exists {
-	// 	file, err := l.Fs.Create(path)
-	// 	if err != nil {
-	// 		return fmt.Errorf("failed to create file: %w", err)
-	// 	}
-	// 	file.Close()
-	// }
 
 	// Update policy
 	currentPolicy.AddAllowedPrincipal(principal, userEmail, issuer)

--- a/opkssh/commands/add.go
+++ b/opkssh/commands/add.go
@@ -75,6 +75,17 @@ func (a *AddCmd) Add(principal string, userEmail string, issuer string) (string,
 	if err != nil {
 		return "", fmt.Errorf("failed to load current policy: %w", err)
 	}
+	// exists, err := afero.Exists(l.Fs, path)
+	// if err != nil {
+	// 	return err
+	// }
+	// if !exists {
+	// 	file, err := l.Fs.Create(path)
+	// 	if err != nil {
+	// 		return fmt.Errorf("failed to create file: %w", err)
+	// 	}
+	// 	file.Close()
+	// }
 
 	// Update policy
 	currentPolicy.AddAllowedPrincipal(principal, userEmail, issuer)

--- a/opkssh/policy/fileloader.go
+++ b/opkssh/policy/fileloader.go
@@ -34,6 +34,21 @@ type FileLoader struct {
 	Fs afero.Fs
 }
 
+func (l FileLoader) CreateIfDoesNotExist(path string) error {
+	exists, err := afero.Exists(l.Fs, path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		file, err := l.Fs.Create(path)
+		if err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		file.Close()
+	}
+	return nil
+}
+
 // LoadFileAtPath validates that the file at path exists, can be read
 // by the current process, and has the correct permission bits set. Parses the
 // contents and returns the bytes if file permissions are valid and

--- a/opkssh/policy/fileloader.go
+++ b/opkssh/policy/fileloader.go
@@ -73,19 +73,6 @@ func (l *FileLoader) validatePermissions(fileInfo fs.FileInfo) error {
 
 // Dump writes fileBytes to the filepath
 func (l *FileLoader) Dump(fileBytes []byte, path string) error {
-
-	exists, err := afero.Exists(l.Fs, path)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		file, err := l.Fs.Create(path)
-		if err != nil {
-			return fmt.Errorf("failed to create file: %w", err)
-		}
-		file.Close()
-	}
-
 	// Write to disk
 	if err := afero.WriteFile(l.Fs, path, fileBytes, ModeOnlyOwner); err != nil {
 		return err

--- a/opkssh/policy/fileloader.go
+++ b/opkssh/policy/fileloader.go
@@ -73,6 +73,19 @@ func (l *FileLoader) validatePermissions(fileInfo fs.FileInfo) error {
 
 // Dump writes fileBytes to the filepath
 func (l *FileLoader) Dump(fileBytes []byte, path string) error {
+
+	exists, err := afero.Exists(l.Fs, path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		file, err := l.Fs.Create(path)
+		if err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		file.Close()
+	}
+
 	// Write to disk
 	if err := afero.WriteFile(l.Fs, path, fileBytes, ModeOnlyOwner); err != nil {
 		return err

--- a/opkssh/policy/fileloader.go
+++ b/opkssh/policy/fileloader.go
@@ -45,6 +45,9 @@ func (l FileLoader) CreateIfDoesNotExist(path string) error {
 			return fmt.Errorf("failed to create file: %w", err)
 		}
 		file.Close()
+		if err := l.Fs.Chmod(path, ModeOnlyOwner); err != nil {
+			return fmt.Errorf("failed to set file permissions: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/openpubkey/openpubkey/issues/267

Ran manual test to determine issue is fixed

![image](https://github.com/user-attachments/assets/56ccdb13-94f6-4728-91b7-4a4bdf6fc5b2)
