### PR TITLE
bug: Fixes hanging bug that opkssh was hitting

### DIFF
--- a/client/choosers/web_chooser.go
+++ b/client/choosers/web_chooser.go
@@ -126,7 +126,7 @@ func (wc *WebChooser) ChooseOp(ctx context.Context) (providers.OpenIdProvider, e
 		shutdownServer := func() {
 			go func() { // Put this in a go func so that it will not block the redirect
 				if wc.server != nil {
-					if err := wc.server.Shutdown(context.Background()); err != nil {
+					if err := wc.server.Shutdown(ctx); err != nil {
 						logrus.Errorf("Failed to shutdown http server: %v", err)
 					}
 				}
@@ -183,6 +183,8 @@ func (wc *WebChooser) ChooseOp(ctx context.Context) (providers.OpenIdProvider, e
 	}
 
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case err := <-errCh:
 		return nil, err
 	case wc.opSelected = <-opCh:


### PR DESCRIPTION
Upstream fix for this bug in opkssh https://github.com/openpubkey/opkssh/issues/29

This was the code which fixed the bug

```golang
select {
  case <-ctx.Done():
    return nil, ctx.Err()
```

The other code change of 
```golang
if err := wc.server.Shutdown(context.Background()); err != nil {
```
to this as well
```golang
if err := wc.server.Shutdown(ctx); err != nil {
```
did not fix the issue but it is better context handling.

related to

https://github.com/openpubkey/openpubkey/issues/238
