### PR TITLE
client: pass crypto.PublicKey instead of crypto.Signer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -189,7 +189,7 @@ func (o *OpkClient) oidcAuth(
 	verifierChecks := []verifier.Check{}
 
 	// Use our signing key to generate a JWK key and set the "alg" header
-	jwkKey, err := jwk.PublicKeyOf(signer)
+	jwkKey, err := jwk.PublicKeyOf(signer.Public())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When implementing abstract crypto.Signers we can't rely on the jwt library to figure out the correct encryption algorith. Passing `crypto.PublicKey` is supported and does the correct thing.