### PR TITLE
bug: Adds tells user URI to open when open browser is disabled

### DIFF
--- a/examples/web/example.go
+++ b/examples/web/example.go
@@ -101,8 +101,10 @@ func login(outputDir string, gqSign bool) error {
 		cancel()
 	}()
 
+	openBrowser := true
 	op, err := choosers.NewWebChooser(
 		[]providers.BrowserOpenIdProvider{googleOp, azureOp},
+		openBrowser,
 	).ChooseOp(ctx)
 	if err != nil {
 		return err

--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -158,10 +158,14 @@ func (s *StandardOp) requestTokens(ctx context.Context, cicHash string) (*simple
 	if s.reuseBrowserWindowHook != nil {
 		s.reuseBrowserWindowHook <- loginURI
 	} else if s.OpenBrowser {
-		logrus.Infof("Opening browser to on %s/", loginURI)
+		logrus.Infof("Opening browser to %s ", loginURI)
 		if err := util.OpenUrl(loginURI); err != nil {
 			logrus.Errorf("Failed to open url: %v", err)
 		}
+	} else {
+		// If s.OpenBrowser is false, tell the user what URL to open.
+		// This is useful when a user wants to use a different browser than the default one.
+		logrus.Infof("Open your browser to: %s ", loginURI)
 	}
 
 	// If httpSessionHook is not defined shutdown the server when done,


### PR DESCRIPTION
This is needed for the bugfix in opkssh https://github.com/openpubkey/opkssh/pull/76 

The bug
https://github.com/openpubkey/opkssh/issues/63

- This PR allows OpenBrowser to be set in the contractor of the Web Chooser to support --disable-browser-open in opkssh 
- It adds output messages in the Web Chooser and Standard Provider to tell users that have set --disable-browser-open to URI they need to manually open to login
- Fixes typo in output message