### PR TITLE
Switch to prompt=select_account

### DIFF
--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -115,7 +115,7 @@ func (s *StandardOp) requestTokens(ctx context.Context, cicHash string) (*simple
 		// Results in better UX than just automatically dropping them into their
 		// only signed in account.
 		// See prompt parameter in OIDC spec https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
-		rp.WithPromptURLParam("consent"),
+		rp.WithPromptURLParam("select_account"),
 		rp.WithURLParam("access_type", "offline")),
 	)
 


### PR DESCRIPTION
This is already what the comment says anyway, and prompt=consent does not work in organizations where consent is restricted to admins