### PR TITLE
feat: discover signing algs to support es256

### DIFF
--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -79,6 +79,7 @@ func (s *StandardOp) requestTokens(ctx context.Context, cicHash string) (*simple
 	}
 	options := []rp.Option{
 		rp.WithCookieHandler(cookieHandler),
+		rp.WithSigningAlgsFromDiscovery(),
 		rp.WithVerifierOpts(
 			rp.WithIssuedAtOffset(s.IssuedAtOffset), rp.WithNonce(
 				func(ctx context.Context) string { return cicHash })),


### PR DESCRIPTION
Adds ability to use ES256 signatures for the OpenID Provider

Needed for: https://github.com/openpubkey/opkssh/issues/131