### PR TITLE
test: Add test coverage for ES256

### DIFF
--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -55,6 +55,7 @@ func TestClient(t *testing.T) {
 			var c *client.OpkClient
 			providerOpts := providers.MockProviderOpts{
 				Issuer:     "mockIssuer",
+				Alg:        "RS256",
 				ClientID:   clientID,
 				GQSign:     tc.gq,
 				NumKeys:    2,

--- a/providers/github_actions_test.go
+++ b/providers/github_actions_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestGithubOpTableTest(t *testing.T) {
 	issuer := githubIssuer
-	providerOverride, err := mocks.NewMockProviderBackend(issuer, 2)
+	providerOverride, err := mocks.NewMockProviderBackend(issuer, "RS256", 2)
 	require.NoError(t, err)
 
 	op := &GithubOp{

--- a/providers/gitlab_ci_test.go
+++ b/providers/gitlab_ci_test.go
@@ -30,7 +30,7 @@ import (
 func TestGitlabSimpleRequest(t *testing.T) {
 
 	issuer := gitlabIssuer
-	providerOverride, err := mocks.NewMockProviderBackend(issuer, 2)
+	providerOverride, err := mocks.NewMockProviderBackend(issuer, "RS256", 2)
 	require.NoError(t, err)
 
 	op := &GitlabCiOp{

--- a/providers/hello.go
+++ b/providers/hello.go
@@ -67,7 +67,7 @@ func GetDefaultHelloOpOptions() *HelloOptions {
 	return &HelloOptions{
 		Issuer:   helloIssuer,
 		ClientID: "app_xejobTKEsDNSRd5vofKB2iay_2rN",
-		Scopes:   []string{"openid profile email"},
+		Scopes:   []string{"openid email"},
 		RedirectURIs: []string{
 			"http://localhost:3000/login-callback",
 			"http://localhost:10001/login-callback",

--- a/providers/mockprovider.go
+++ b/providers/mockprovider.go
@@ -34,6 +34,7 @@ var _ OpenIdProvider = (*MockProvider)(nil)
 
 type MockProviderOpts struct {
 	Issuer     string
+	Alg        string
 	ClientID   string
 	GQSign     bool
 	NumKeys    int
@@ -47,6 +48,7 @@ func DefaultMockProviderOpts() MockProviderOpts {
 	clientID := "test_client_id"
 	return MockProviderOpts{
 		Issuer:     "https://accounts.example.com",
+		Alg:        "RS256",
 		ClientID:   clientID,
 		GQSign:     false,
 		NumKeys:    2,
@@ -75,7 +77,10 @@ func NewMockProvider(opts MockProviderOpts) (*MockProvider, *mocks.MockProviderB
 	if opts.Issuer == "" {
 		opts.Issuer = mockProviderIssuer
 	}
-	mockBackend, err := mocks.NewMockProviderBackend(opts.Issuer, opts.NumKeys)
+	if opts.Alg == "" {
+		opts.Alg = "RS256"
+	}
+	mockBackend, err := mocks.NewMockProviderBackend(opts.Issuer, opts.Alg, opts.NumKeys)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/providers/mocks/backend.go
+++ b/providers/mocks/backend.go
@@ -41,10 +41,21 @@ type MockProviderBackend struct {
 	IDTokensTemplate      *IDTokenTemplate
 }
 
-func NewMockProviderBackend(issuer string, numKeys int) (*MockProviderBackend, error) {
-	providerSigningKeySet, providerPublicKeySet, err := CreateRS256KeySet(issuer, numKeys)
-	if err != nil {
-		return nil, err
+func NewMockProviderBackend(issuer string, alg string, numKeys int) (*MockProviderBackend, error) {
+
+	var providerSigningKeySet map[string]crypto.Signer
+	var providerPublicKeySet map[string]discover.PublicKeyRecord
+	var err error
+	if alg == "RS256" {
+		if providerSigningKeySet, providerPublicKeySet, err = CreateRS256KeySet(issuer, numKeys); err != nil {
+			return nil, err
+		}
+	} else if alg == "ES256" {
+		if providerSigningKeySet, providerPublicKeySet, err = CreateES256KeySet(issuer, numKeys); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported provider alg: %s", alg)
 	}
 
 	return &MockProviderBackend{

--- a/providers/mocks/backend_test.go
+++ b/providers/mocks/backend_test.go
@@ -33,7 +33,7 @@ import (
 func TestSimpleBackendOverride(t *testing.T) {
 
 	issuer := "https://accounts.example.com/"
-	mockBackend, err := NewMockProviderBackend(issuer, 3)
+	mockBackend, err := NewMockProviderBackend(issuer, "RS256", 3)
 	require.NoError(t, err)
 
 	expSigningKey, expKeyID, expRecord := mockBackend.RandomSigningKey()

--- a/providers/standard_provider_test.go
+++ b/providers/standard_provider_test.go
@@ -31,7 +31,7 @@ func TestGoogleSimpleRequest(t *testing.T) {
 	gqSign := false
 
 	issuer := googleIssuer
-	providerOverride, err := mocks.NewMockProviderBackend(issuer, 2)
+	providerOverride, err := mocks.NewMockProviderBackend(issuer, "RS256", 2)
 	require.NoError(t, err)
 
 	op := &GoogleOp{

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -33,9 +33,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func NewMockOpenIdProvider(gqSign bool, issuer string, clientID string, extraClaims map[string]any) (providers.OpenIdProvider, *mocks.MockProviderBackend, error) {
+func NewMockOpenIdProvider(gqSign bool, issuer string, alg string, clientID string, extraClaims map[string]any) (providers.OpenIdProvider, *mocks.MockProviderBackend, error) {
 	providerOpts := providers.MockProviderOpts{
 		Issuer:     issuer,
+		Alg:        alg,
 		ClientID:   clientID,
 		GQSign:     gqSign,
 		NumKeys:    2,
@@ -76,12 +77,12 @@ func TestVerifier(t *testing.T) {
 
 	noGQSign := false
 	GQSign := true
-	provider, backend, err := NewMockOpenIdProvider(noGQSign, issuer, clientID, map[string]any{
+	provider, backend, err := NewMockOpenIdProvider(noGQSign, issuer, "RS256", clientID, map[string]any{
 		"aud": clientID,
 	})
 	require.NoError(t, err)
 
-	providerGQ, backendGQ, err := NewMockOpenIdProvider(GQSign, issuer+"-gq", clientID, map[string]any{
+	providerGQ, backendGQ, err := NewMockOpenIdProvider(GQSign, issuer+"-gq", "RS256", clientID, map[string]any{
 		"aud": clientID,
 	})
 	require.NoError(t, err)
@@ -143,7 +144,7 @@ func TestVerifier(t *testing.T) {
 	// If audience is a list of strings, make sure verification holds. We use
 	// extraClaims because it is resolved just token creation time, allowing
 	// us to bypass the clientID being set by the constructor.
-	provider, backend, err = NewMockOpenIdProvider(noGQSign, issuer, clientID, map[string]any{
+	provider, backend, err = NewMockOpenIdProvider(noGQSign, issuer, "RS256", clientID, map[string]any{
 		"aud": []string{clientID},
 	})
 	require.NoError(t, err)
@@ -212,7 +213,7 @@ func TestVerifierRefreshedIDToken(t *testing.T) {
 	// commitType := providers.CommitTypesEnum.NONCE_CLAIM
 
 	noGQSign := false
-	provider, _, err := NewMockOpenIdProvider(noGQSign, issuer, clientID, map[string]any{
+	provider, _, err := NewMockOpenIdProvider(noGQSign, issuer, "RS256", clientID, map[string]any{
 		"aud": clientID,
 	})
 	require.NoError(t, err)
@@ -239,7 +240,7 @@ func TestVerifierExpirationPolicy(t *testing.T) {
 	clientID := "verifier"
 
 	noGQSign := false
-	provider, mockBackend, err := NewMockOpenIdProvider(noGQSign, issuer, clientID, map[string]any{
+	provider, mockBackend, err := NewMockOpenIdProvider(noGQSign, issuer, "RS256", clientID, map[string]any{
 		"aud": clientID,
 	})
 	require.NoError(t, err)
@@ -363,6 +364,7 @@ func TestGQCommitment(t *testing.T) {
 
 			clientID := "test_client_id"
 			providerOpts := providers.MockProviderOpts{
+				Alg:        "RS256",
 				ClientID:   clientID,
 				GQSign:     tc.gqSign,
 				NumKeys:    2,


### PR DESCRIPTION
PR https://github.com/openpubkey/openpubkey/pull/311 added support for OPs that sign ID Token with ES256 (ECDSA) rather than RS256 (RSA). This PR adds minimal test coverage for ES256 signed ID Tokens.

Also removes profile from hello.dev scopes.

Relates to https://github.com/openpubkey/opkssh/issues/131

