### PR TITLE
Fixes web chooser test that was breaking due to resolving example.com

### DIFF
--- a/client/choosers/web_chooser_test.go
+++ b/client/choosers/web_chooser_test.go
@@ -115,13 +115,10 @@ func TestGoogleSelection(t *testing.T) {
 					azureOp.(*providers.StandardOp).TriggerBrowserWindowHook(redirectUri)
 				}
 
-				// Wait no longer than 100ms for the redirect to be triggered
-				wait := 0
-				for gotRedirect == false && wait < 100 {
-					time.Sleep(1 * time.Millisecond)
-					wait++
-				}
-				require.True(t, gotRedirect, "redirect not triggered but should have been")
+				require.Eventually(t,
+					func() bool { return gotRedirect },
+					100*time.Millisecond, 1*time.Millisecond, "redirect not triggered but should have been",
+				)
 			}()
 
 			// Wait until the server is listening

--- a/client/choosers/web_chooser_test.go
+++ b/client/choosers/web_chooser_test.go
@@ -32,12 +32,10 @@ func CreateServerToHandleRedirect(t *testing.T, gotRedirect *bool) (*httptest.Se
 	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
 		*gotRedirect = true
 		w.WriteHeader(http.StatusOK)
-		return
 	})
 	mockServer := httptest.NewUnstartedServer(mux)
 	mockServer.Start()
-	redirectUri := mockServer.URL + "/redirect"
-	return mockServer, redirectUri
+	return mockServer, mockServer.URL + "/redirect"
 }
 
 func TestGoogleSelection(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/openpubkey/openpubkey/issues/323

The web_chooser_test was calling out to http://example.com. This was noticed when the unittest was run in an environment that had no internet. This PR changes the test to use a local webserver.

