### PR TITLE
feat: parse more fields in oidc claims

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -26,16 +26,18 @@ import (
 )
 
 type OidcClaims struct {
-	Issuer     string `json:"iss"`
-	Subject    string `json:"sub"`
-	Audience   string `json:"-"`
-	Expiration int64  `json:"exp"`
-	IssuedAt   int64  `json:"iat"`
-	Email      string `json:"email,omitempty"`
-	Nonce      string `json:"nonce,omitempty"`
-	Username   string `json:"preferred_username,omitempty"`
-	FirstName  string `json:"given_name,omitempty"`
-	LastName   string `json:"family_name,omitempty"`
+	Issuer     string   `json:"iss"`
+	Subject    string   `json:"sub"`
+	Audience   string   `json:"-"`
+	Expiration int64    `json:"exp"`
+	IssuedAt   int64    `json:"iat"`
+	Email      string   `json:"email,omitempty"`
+	Nonce      string   `json:"nonce,omitempty"`
+	Username   string   `json:"preferred_username,omitempty"`
+	FirstName  string   `json:"given_name,omitempty"`
+	LastName   string   `json:"family_name,omitempty"`
+	Groups     []string `json:"groups,omitempty"`
+	Scopes     []string `json:"scopes,omitempty"`
 }
 
 // Implement UnmarshalJSON for custom handling during JSON unmarshalling


### PR DESCRIPTION
This helped me debug https://github.com/openpubkey/opkssh/issues/173 and implement https://github.com/openpubkey/opkssh/pull/174

This can help both developers and users to better understand what information were exchanged when debugging issues. The new output of `opkssh login --print-id-token` for me is now

```
{
  "iss": "https://sso.kammel.dev/oauth2/openid/opkssh",
  "sub": "7b89b6ea-1e8b-4aa8-98fb-a70cba498d16",
  "aud": "opkssh",
  "exp": 1746271370,
  "nbf": 1746270470,
  "iat": 1746270470,
  "nonce": "v_u0w3-CJh0h0Q5h332K_UkK-wwQeAq78srbVD2ZGNk",
  "azp": "opkssh",
  "name": "Fabian Kammel",
  "preferred_username": "datosh@sso.kammel.dev",
  "email": "fabian@kammel.dev",
  "email_verified": true,
  "scopes": [
    "email",
    "groups",
    "openid",
    "profile"
  ],
  "groups": [
    "idm_all_persons@sso.kammel.dev",
    "00000000-0000-0000-0000-000000000035",
    "idm_all_accounts@sso.kammel.dev",
    "00000000-0000-0000-0000-000000000036",
    "idm_people_self_name_write@sso.kammel.dev",
    "00000000-0000-0000-0000-000000000048",
    "k8s_users@sso.kammel.dev",
    "3e266cf4-5f10-4def-913b-9ae2b109430f",
    "opkssh_users@sso.kammel.dev",
    "9eb7ee16-740a-4c61-aaa9-ceb05501134a"
  ]
}
```

This helps especially with providing the correct values for `sudo opkssh add root oidc:groups:<group_name> provider` because group names aren't always obvious. 

Happy to change/extend the implementation based on your feedback! 