### PR TITLE
Creates Access token getter in client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -281,6 +281,10 @@ func (o *OpkClient) GetAlg() jwa.KeyAlgorithm {
 	return o.alg
 }
 
+func (o *OpkClient) GetAccessToken() []byte {
+	return o.accessToken
+}
+
 func (o *OpkClient) SetPKToken(pkt *pktoken.PKToken) {
 	o.pkToken = pkt
 }

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -53,14 +53,14 @@ type PKToken struct {
 	Cos     *Signature // Cosigner Signature
 
 	// We keep the tokens around as  unmarshalled values can no longer be verified
-	OpToken  []byte // Base64 encoded ID Token signed by the OP
-	CicToken []byte // Base64 encoded Token signed by the Client
-	CosToken []byte // Base64 encoded Token signed by the Cosigner
+	OpToken  []byte // Compact encoded ID Token signed by the OP, i.e., Base64(Protected).Base64(Payload).Base64(Sig)
+	CicToken []byte // Compact encoded Token signed by the Client
+	CosToken []byte // Compact encoded Token signed by the Cosigner
 
 	// FreshIDToken is the refreshed ID Token. It has a different payload from
 	// other tokens and must be handled separately.
 	// It is only used for POP Authentication
-	FreshIDToken []byte // Base64 encoded Refreshed ID Token
+	FreshIDToken []byte // Compact encoded Refreshed ID Token
 }
 
 // New creates a new PKToken from an ID Token and a CIC Token.

--- a/providers/gq_test.go
+++ b/providers/gq_test.go
@@ -76,7 +76,7 @@ func TestGQ(t *testing.T) {
 
 			expPublicKey := maps.Values(backend.GetProviderPublicKeySet())[0].PublicKey
 
-			tokens, err := idtTemplate.IssueToken()
+			tokens, err := idtTemplate.IssueTokens()
 			require.NoError(t, err)
 			idToken := tokens.IDToken
 

--- a/providers/mocks/backend.go
+++ b/providers/mocks/backend.go
@@ -106,7 +106,7 @@ func (o *MockProviderBackend) SetIDTokenTemplate(template *IDTokenTemplate) {
 
 func (o *MockProviderBackend) RequestTokensOverrideFunc(cicHash string) (*oidc.Tokens, error) {
 	o.IDTokensTemplate.AddCommit(cicHash)
-	return o.IDTokensTemplate.IssueToken()
+	return o.IDTokensTemplate.IssueTokens()
 }
 
 func (o *MockProviderBackend) RandomSigningKey() (crypto.Signer, string, discover.PublicKeyRecord) {

--- a/providers/mocks/idtoken.go
+++ b/providers/mocks/idtoken.go
@@ -69,8 +69,7 @@ func (t *IDTokenTemplate) AddCommit(cicHash string) {
 	t.CommitFunc(t, cicHash)
 }
 
-// TODO: Rename to IssueTokens
-func (t *IDTokenTemplate) IssueToken() (*oidc.Tokens, error) {
+func (t *IDTokenTemplate) IssueTokens() (*oidc.Tokens, error) {
 
 	headers := jws.NewHeaders()
 	if !t.NoAlg {


### PR DESCRIPTION
We currently save the access token in the client struct but it is not accessible. This PR makes it accessible by creating a GetAccessToken func.

- Minor fix TODO: Rename to IssueTokens
