### PR TITLE
Pass client secret opt to standard provider

### DIFF
--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -102,6 +102,7 @@ func GetDefaultStandardOpOptions(issuer string, clientID string) *StandardOpOpti
 func NewStandardOpWithOptions(opts *StandardOpOptions) BrowserOpenIdProvider {
 	return &StandardOp{
 		clientID:                  opts.ClientID,
+		ClientSecret:              opts.ClientSecret,
 		Scopes:                    opts.Scopes,
 		PromptType:                opts.PromptType,
 		AccessType:                opts.AccessType,


### PR DESCRIPTION
I think it's pretty self-explanatory.
I believe the client secret should be passed from opts to `StandardOp`.

I found that by using `github.com/oauth2-proxy/mockoidc` in one of my tests - this mock requires client_secret.

This fix makes it work (confirmed the behavior with keycloak as well).