### PR TITLE
feat: Adds ability to call userinfo on providers

### DIFF
--- a/examples/userinfo/example.go
+++ b/examples/userinfo/example.go
@@ -1,0 +1,119 @@
+// Copyright 2025 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/awnumar/memguard"
+
+	"github.com/openpubkey/openpubkey/client"
+	"github.com/openpubkey/openpubkey/client/choosers"
+	"github.com/openpubkey/openpubkey/providers"
+)
+
+func main() {
+	// Safely terminate in case of an interrupt signal
+	memguard.CatchInterrupt()
+
+	// Purge the session when we return
+	defer memguard.Purge()
+
+	if len(os.Args) < 2 {
+		fmt.Printf("OpenPubkey: command choices are login")
+		return
+	}
+
+	command := os.Args[1]
+	switch command {
+	case "login":
+		if err := login(); err != nil {
+			fmt.Println("Error logging in:", err)
+		} else {
+			fmt.Println("Login successful!")
+		}
+	default:
+		fmt.Println("Unrecognized command:", command)
+	}
+}
+
+func login() error {
+	googleOpOptions := providers.GetDefaultGoogleOpOptions()
+	googleOp := providers.NewGoogleOpWithOptions(googleOpOptions)
+
+	azureOpOptions := providers.GetDefaultAzureOpOptions()
+	azureOp := providers.NewAzureOpWithOptions(azureOpOptions)
+
+	gitlabOpOptions := providers.GetDefaultGitlabOpOptions()
+	gitlabOp := providers.NewGitlabOpWithOptions(gitlabOpOptions)
+
+	helloOpOptions := providers.GetDefaultHelloOpOptions()
+	helloOp := providers.NewHelloOpWithOptions(helloOpOptions)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		fmt.Printf("Received shutdown signal, exiting... %v\n", sigs)
+		cancel()
+	}()
+
+	openBrowser := true
+	op, err := choosers.NewWebChooser(
+		[]providers.BrowserOpenIdProvider{googleOp, azureOp, helloOp, gitlabOp},
+		openBrowser,
+	).ChooseOp(ctx)
+	if err != nil {
+		return err
+	}
+
+	opkClient, err := client.New(op)
+	if err != nil {
+		return err
+	}
+
+	pkt, err := opkClient.Auth(ctx)
+	if err != nil {
+		return err
+	}
+
+	sub, err := pkt.Subscriber()
+	if err != nil {
+		return err
+	}
+
+	fullOp, ok := op.(providers.BrowserOpenIdProvider)
+	if !ok {
+		return fmt.Errorf("failed to cast to BrowserOpenIdProvider")
+	}
+
+	accessToken := opkClient.GetAccessToken()
+	fmt.Println("AccessToken", string(accessToken))
+
+	userinfo, err := fullOp.UserInfo(ctx, opkClient.GetAccessToken(), sub)
+	if err != nil {
+		return err
+	}
+	fmt.Println("UserInfo", string(userinfo))
+
+	return nil
+}

--- a/providers/mocks/userinfo.go
+++ b/providers/mocks/userinfo.go
@@ -1,0 +1,120 @@
+// Copyright 2025 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const googleWellknownResponse = `{
+	"issuer": "https://accounts.google.com",
+	"authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+	"device_authorization_endpoint": "https://oauth2.googleapis.com/device/code",
+	"token_endpoint": "https://oauth2.googleapis.com/token",
+	"userinfo_endpoint": "https://openidconnect.googleapis.com/v1/userinfo",
+	"revocation_endpoint": "https://oauth2.googleapis.com/revoke",
+	"jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+	"response_types_supported": [
+		"code",
+		"token",
+		"id_token",
+		"code token",
+		"code id_token",
+		"token id_token",
+		"code token id_token",
+		"none"
+	],
+	"subject_types_supported": [
+		"public"
+	],
+	"id_token_signing_alg_values_supported": [
+		"RS256"
+	],
+	"scopes_supported": [
+		"openid",
+		"email",
+		"profile"
+	],
+	"token_endpoint_auth_methods_supported": [
+		"client_secret_post",
+		"client_secret_basic"
+	],
+	"claims_supported": [
+		"aud",
+		"email",
+		"email_verified",
+		"exp",
+		"family_name",
+		"given_name",
+		"iat",
+		"iss",
+		"name",
+		"picture",
+		"sub"
+	],
+	"code_challenge_methods_supported": [
+		"plain",
+		"S256"
+	],
+	"grant_types_supported": [
+		"authorization_code",
+		"refresh_token",
+		"urn:ietf:params:oauth:grant-type:device_code",
+		"urn:ietf:params:oauth:grant-type:jwt-bearer"
+	]
+}`
+
+func NewMockGoogleUserInfoHTTPClient(userInfoResponse string) *http.Client {
+	return NewMockUserInfoClient(
+		"https://accounts.google.com/.well-known/openid-configuration",
+		"https://openidconnect.googleapis.com/v1/userinfo",
+		googleWellknownResponse,
+		userInfoResponse,
+	)
+}
+
+func NewMockUserInfoClient(wellKnownUri string, userInfoUri string, wellknownResponse string, userInfoResponse string) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method == http.MethodGet && strings.HasPrefix(req.URL.String(), wellKnownUri) {
+				return &http.Response{
+					StatusCode: 200,
+					Header:     http.Header{"Content-Type": {"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(wellknownResponse)),
+				}, nil
+			}
+
+			if req.Method == http.MethodGet && req.URL.String() == userInfoUri {
+				return &http.Response{
+					StatusCode: 200,
+					Header:     http.Header{"Content-Type": {"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(userInfoResponse)),
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected HTTP call to %s %s", req.Method, req.URL)
+		}),
+	}
+}
+
+type RoundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/providers/op.go
+++ b/providers/op.go
@@ -41,6 +41,7 @@ type OpenIdProvider interface {
 type BrowserOpenIdProvider interface {
 	OpenIdProvider
 	ClientID() string
+	UserInfo(ctx context.Context, accessToken []byte, subject string) (string, error)
 	HookHTTPSession(h http.HandlerFunc)
 	ReuseBrowserWindowHook(chan string)
 }

--- a/providers/standard_provider_test.go
+++ b/providers/standard_provider_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const userInfoResponse = `{
+	"sub": "me",
+	"email": "alice@example.com",
+	"name": "Alice Example"
+}`
+
 func TestGoogleSimpleRequest(t *testing.T) {
 	gqSign := false
 
@@ -34,11 +40,14 @@ func TestGoogleSimpleRequest(t *testing.T) {
 	providerOverride, err := mocks.NewMockProviderBackend(issuer, "RS256", 2)
 	require.NoError(t, err)
 
+	httpClient := mocks.NewMockGoogleUserInfoHTTPClient(userInfoResponse)
+
 	op := &GoogleOp{
 		StandardOp{
 			issuer:                    googleIssuer,
 			publicKeyFinder:           providerOverride.PublicKeyFinder,
 			requestTokensOverrideFunc: providerOverride.RequestTokensOverrideFunc,
+			HttpClient:                httpClient,
 		},
 	}
 
@@ -89,4 +98,10 @@ func TestGoogleSimpleRequest(t *testing.T) {
 
 	require.Equal(t, "mock-refresh-token", string(tokens.RefreshToken))
 	require.Equal(t, "mock-access-token", string(tokens.AccessToken))
+
+	userInfoJson, err := op.UserInfo(context.Background(), tokens.AccessToken, "me")
+	require.NoError(t, err)
+
+	require.Contains(t, userInfoJson, `"email":"alice@example.com"`)
+	require.Contains(t, userInfoJson, `"sub":"me"`)
 }


### PR DESCRIPTION
Adds new function to certain providers that allows someone with the access token to call userinfo endpoint.

Related to work being done in opkssh https://github.com/openpubkey/opkssh/pull/183

This has a unittest, but I also manually tested against: Google, Azure, Github and Hello

