### PR TITLE
Moves UserInfo look up to verifier

### DIFF
--- a/examples/userinfo/example.go
+++ b/examples/userinfo/example.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/client/choosers"
 	"github.com/openpubkey/openpubkey/providers"
+	"github.com/openpubkey/openpubkey/verifier"
 )
 
 func main() {
@@ -96,24 +97,19 @@ func login() error {
 		return err
 	}
 
-	sub, err := pkt.Subject()
-	if err != nil {
-		return err
-	}
-
-	fullOp, ok := op.(providers.BrowserOpenIdProvider)
-	if !ok {
-		return fmt.Errorf("failed to cast to BrowserOpenIdProvider")
-	}
-
 	accessToken := opkClient.GetAccessToken()
 	fmt.Println("AccessToken", string(accessToken))
 
-	userinfo, err := fullOp.UserInfo(ctx, opkClient.GetAccessToken(), sub)
+	uiRequester, err := verifier.NewUserInfoRequester(pkt, string(accessToken))
 	if err != nil {
 		return err
 	}
-	fmt.Println("UserInfo", string(userinfo))
+
+	userInfoJson, err := uiRequester.Request(context.Background())
+	if err != nil {
+		return err
+	}
+	fmt.Println("UserInfo", string(userInfoJson))
 
 	return nil
 }

--- a/examples/userinfo/example.go
+++ b/examples/userinfo/example.go
@@ -96,7 +96,7 @@ func login() error {
 		return err
 	}
 
-	sub, err := pkt.Subscriber()
+	sub, err := pkt.Subject()
 	if err != nil {
 		return err
 	}

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -137,22 +137,22 @@ func (p *PKToken) Audience() (string, error) {
 	return claims.Audience, nil
 }
 
-// Subscriber returns the subscriber (`sub`) of the ID Token in the PKToken.
+// Subject returns the subject (`sub`) of the ID Token in the PKToken.
 // This is a unique identifier for the user at the OpenID Provider.
-func (p *PKToken) Subscriber() (string, error) {
+func (p *PKToken) Subject() (string, error) {
 	var claims struct {
-		Subscriber string `json:"sub"`
+		Subject string `json:"sub"`
 	}
 	if err := json.Unmarshal(p.Payload, &claims); err != nil {
 		return "", fmt.Errorf("malformatted PK token claims: %w", err)
 	}
-	return claims.Subscriber, nil
+	return claims.Subject, nil
 }
 
 // IdentityString string returns the three attributes that are used to uniquely identify a user
-// in the OpenID Connect protocol: the subscriber, the issuer
+// in the OpenID Connect protocol: the subject, the issuer
 func (p *PKToken) IdentityString() (string, error) {
-	sub, err := p.Subscriber()
+	sub, err := p.Subject()
 	if err != nil {
 		return "", err
 	}

--- a/providers/op.go
+++ b/providers/op.go
@@ -41,7 +41,6 @@ type OpenIdProvider interface {
 type BrowserOpenIdProvider interface {
 	OpenIdProvider
 	ClientID() string
-	UserInfo(ctx context.Context, accessToken []byte, subject string) (string, error)
 	HookHTTPSession(h http.HandlerFunc)
 	ReuseBrowserWindowHook(chan string)
 }

--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -412,44 +412,9 @@ func (s *StandardOpRefreshable) VerifyRefreshedIDToken(ctx context.Context, orig
 	return err
 }
 
-// UserInfo calls OpenID Provider's user info endpoint using the provided access token.
-// The access token must match subject (sub claim) in the ID token issued alongside that
-// access token. This function returns the user info JSON as a string.
-func (s *StandardOp) UserInfo(ctx context.Context, accessToken []byte, subject string) (string, error) {
-	httpClient := http.DefaultClient
-	if s.HttpClient != nil {
-		httpClient = s.HttpClient
-	}
-
-	// We use zitadel/oidc to call the userinfo endpoint rather than calling
-	// the endpoint directly to take advantage of the zitadel's ability to use
-	// HTTP proxies in requests.
-	relyingParty, err := rp.NewRelyingPartyOIDC(ctx, s.issuer, "", "", "", nil, rp.WithHTTPClient(httpClient))
-	if err != nil {
-		return "", err
-	}
-	info, err := rp.Userinfo[*oidc.UserInfo](
-		ctx,
-		string(accessToken),
-		"Bearer",
-		subject,
-		relyingParty,
-	)
-	if err != nil {
-		return "", err
-	}
-
-	jsonInfo, err := info.MarshalJSON()
-	if err != nil {
-		return "", err
-	}
-
-	return string(jsonInfo), nil
-}
-
 // HookHTTPSession provides a means to hook the HTTP Server session resulting
 // from the OpenID Provider sending an authcode to the OIDC client by
-// redirecting the user's browser with the authcode supplied in the URI.
+// redirecting the users browser with the authcode supplied in the URI.
 // If this hook is set, it will be called after the receiving the authcode
 // but before send an HTTP response to the user. The code which sets this hook
 // can choose what HTTP response to server to the user.

--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -414,7 +414,7 @@ func (s *StandardOpRefreshable) VerifyRefreshedIDToken(ctx context.Context, orig
 
 // HookHTTPSession provides a means to hook the HTTP Server session resulting
 // from the OpenID Provider sending an authcode to the OIDC client by
-// redirecting the users browser with the authcode supplied in the URI.
+// redirecting the user's browser with the authcode supplied in the URI.
 // If this hook is set, it will be called after the receiving the authcode
 // but before send an HTTP response to the user. The code which sets this hook
 // can choose what HTTP response to server to the user.

--- a/providers/standard_provider_test.go
+++ b/providers/standard_provider_test.go
@@ -27,12 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const userInfoResponse = `{
-	"sub": "me",
-	"email": "alice@example.com",
-	"name": "Alice Example"
-}`
-
 func TestGoogleSimpleRequest(t *testing.T) {
 	gqSign := false
 
@@ -40,14 +34,11 @@ func TestGoogleSimpleRequest(t *testing.T) {
 	providerOverride, err := mocks.NewMockProviderBackend(issuer, "RS256", 2)
 	require.NoError(t, err)
 
-	httpClient := mocks.NewMockGoogleUserInfoHTTPClient(userInfoResponse)
-
 	op := &GoogleOp{
 		StandardOp{
 			issuer:                    googleIssuer,
 			publicKeyFinder:           providerOverride.PublicKeyFinder,
 			requestTokensOverrideFunc: providerOverride.RequestTokensOverrideFunc,
-			HttpClient:                httpClient,
 		},
 	}
 
@@ -98,10 +89,4 @@ func TestGoogleSimpleRequest(t *testing.T) {
 
 	require.Equal(t, "mock-refresh-token", string(tokens.RefreshToken))
 	require.Equal(t, "mock-access-token", string(tokens.AccessToken))
-
-	userInfoJson, err := op.UserInfo(context.Background(), tokens.AccessToken, "me")
-	require.NoError(t, err)
-
-	require.Contains(t, userInfoJson, `"email":"alice@example.com"`)
-	require.Contains(t, userInfoJson, `"sub":"me"`)
 }

--- a/verifier/userinfo.go
+++ b/verifier/userinfo.go
@@ -1,0 +1,85 @@
+// Copyright 2025 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/openpubkey/openpubkey/pktoken"
+	"github.com/zitadel/oidc/v3/pkg/client/rp"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+type UserInfoRequester struct {
+	Issuer      string
+	Subject     string
+	AccessToken string
+	HttpClient  *http.Client
+}
+
+func NewUserInfoRequester(pkt *pktoken.PKToken, accessToken string) (*UserInfoRequester, error) {
+	issuer, err := pkt.Issuer()
+	if err != nil {
+		return nil, err
+	}
+	sub, err := pkt.Subject()
+	if err != nil {
+		return nil, err
+	}
+	return &UserInfoRequester{
+		Issuer:      issuer,
+		Subject:     sub,
+		AccessToken: accessToken,
+	}, nil
+}
+
+// Request calls OpenID Provider's user info endpoint using the provided access token.
+// The access token must match subject (sub claim) in the ID token issued alongside that
+// access token. This function returns the user info JSON as a string.
+func (ui *UserInfoRequester) Request(ctx context.Context) (string, error) {
+
+	httpClient := http.DefaultClient
+	if ui.HttpClient != nil {
+		httpClient = ui.HttpClient
+	}
+
+	// We use zitadel/oidc to call the userinfo endpoint rather than calling
+	// the endpoint directly to take advantage of the zitadel's ability to use
+	// HTTP proxies in requests.
+	relyingParty, err := rp.NewRelyingPartyOIDC(ctx, ui.Issuer, "", "", "", nil, rp.WithHTTPClient(httpClient))
+	if err != nil {
+		return "", err
+	}
+	info, err := rp.Userinfo[*oidc.UserInfo](
+		ctx,
+		ui.AccessToken,
+		"Bearer",
+		ui.Subject,
+		relyingParty,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	jsonInfo, err := info.MarshalJSON()
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonInfo), nil
+}

--- a/verifier/userinfo_test.go
+++ b/verifier/userinfo_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openpubkey/openpubkey/client"
+	"github.com/openpubkey/openpubkey/providers/mocks"
+	"github.com/openpubkey/openpubkey/verifier"
+	"github.com/stretchr/testify/require"
+)
+
+const userInfoResponse = `{
+	"sub": "me",
+	"email": "alice@example.com",
+	"name": "Alice Example"
+}`
+
+func TestGoogleSimpleRequest(t *testing.T) {
+	issuer := "https://accounts.google.com"
+	clientID := "verifier"
+
+	noGQSign := false
+	provider, _, err := NewMockOpenIdProvider(noGQSign, issuer, "RS256", clientID, map[string]any{
+		"aud": clientID,
+	})
+	require.NoError(t, err)
+	opkClient, err := client.New(provider)
+	require.NoError(t, err)
+	pkt, err := opkClient.Auth(context.Background())
+	require.NoError(t, err)
+
+	accessToken := opkClient.GetAccessToken()
+	require.NotEmpty(t, accessToken)
+
+	require.Equal(t, "mock-access-token", string(accessToken))
+
+	uiRequester, err := verifier.NewUserInfoRequester(pkt, string(accessToken))
+	require.NoError(t, err)
+
+	uiRequester.HttpClient = mocks.NewMockGoogleUserInfoHTTPClient(userInfoResponse)
+	userInfoJson, err := uiRequester.Request(context.Background())
+	require.NoError(t, err)
+
+	require.Contains(t, userInfoJson, `"email":"alice@example.com"`)
+	require.Contains(t, userInfoJson, `"sub":"me"`)
+}


### PR DESCRIPTION
Creates a userinfo struct in verifier for looking up userinfo from a pktoken

Also:
- Fixes incorrectly named JWT claim (sub). This is a breaking change if anyone was using the pktoken.Subscriber() function.