### PR TITLE
feat: add GitHub Actions example, integration workflow, and harden CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,10 +2,6 @@ name: Go Checks
 
 on:
   push:
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
   pull_request:
     paths:
       - "**.go"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,11 @@
 name: Go Checks
 
 on:
+  push:
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
   pull_request:
     paths:
       - "**.go"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,7 @@ jobs:
   gotest:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,28 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  github-actions-integration:
+    name: GitHub Actions OIDC Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run integration tests
+        run: go test -tags integration -v ./examples/github_actions/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main" ] # SECURITY CRITICAL: DO NOT delete this line, DO NOT allow this to run on other branches. This integration tests can read github ID Tokens for this project.
 
 jobs:
   github-actions-integration:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,7 @@ jobs:
   codecov:
     name: Push to main test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/examples/github_actions/example.go
+++ b/examples/github_actions/example.go
@@ -1,0 +1,101 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package github_actions_example
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/openpubkey/openpubkey/client"
+	"github.com/openpubkey/openpubkey/providers"
+	"github.com/openpubkey/openpubkey/verifier"
+)
+
+type Opts struct {
+	altOp providers.OpenIdProvider
+}
+
+func SignWithGithubActions(opts ...Opts) error {
+	var op providers.OpenIdProvider
+	var err error
+
+	// If an alternative OP is provided, use that instead of the default.
+	// Currently only used for testing where a mockOP is provided.
+	if len(opts) > 0 && opts[0].altOp != nil {
+		op = opts[0].altOp
+	} else {
+		// Creates OpenID Provider (OP) from GitHub Actions environment variables
+		op, err = providers.NewGithubOpFromEnvironment()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Creates a new OpenPubkey client
+	opkClient, err := client.New(op)
+	if err != nil {
+		return err
+	}
+
+	// Generates a PK Token by authorizing to the OpenID Provider
+	pkt, err := opkClient.Auth(context.Background())
+	if err != nil {
+		return err
+	}
+
+	// Serialize the PK Token to JSON so we can print it. Typically this
+	// serialization of the PK Token would be sent with the signed message
+	pktJson, err := pkt.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	fmt.Println("pkt:", string(pktJson))
+
+	pktCom, _ := pkt.Compact()
+	b64pktCom := base64.StdEncoding.EncodeToString(pktCom)
+	fmt.Println("pkt compact:", string(b64pktCom))
+
+	// Create a verifier to check that the PK Token is well formed
+	verifier, err := verifier.New(op)
+	if err != nil {
+		return err
+	}
+
+	// Verify the PK Token
+	err = verifier.VerifyPKToken(context.Background(), pkt)
+	if err != nil {
+		return err
+	}
+
+	// Sign a message over the user's public key in the PK Token
+	msg := []byte("All is discovered - flee at once")
+	signedMsg, err := pkt.NewSignedMessage(msg, opkClient.GetSigner())
+	if err != nil {
+		return err
+	}
+	fmt.Println("signedMsg:", string(signedMsg))
+
+	// Verify the signed message
+	_, err = pkt.VerifySignedMessage(signedMsg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Success!")
+	return nil
+}

--- a/examples/github_actions/example_integration_test.go
+++ b/examples/github_actions/example_integration_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package github_actions_example
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGithubActionsIntegration(t *testing.T) {
+	// This test runs only in GitHub Actions with id-token: write permission.
+	// It exercises the real OIDC flow against GitHub's token endpoint.
+	err := SignWithGithubActions()
+	require.NoError(t, err)
+}

--- a/examples/github_actions/example_test.go
+++ b/examples/github_actions/example_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package github_actions_example
+
+import (
+	"testing"
+
+	"github.com/openpubkey/openpubkey/providers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGithubActionsExample(t *testing.T) {
+	providerOpts := providers.MockProviderOpts{
+		Issuer:     "https://token.actions.githubusercontent.com",
+		ClientID:   "test_client_id",
+		GQSign:     true,
+		NumKeys:    2,
+		CommitType: providers.CommitTypesEnum.AUD_CLAIM,
+		VerifierOpts: providers.ProviderVerifierOpts{
+			SkipClientIDCheck: true,
+			GQOnly:            true,
+			CommitType:        providers.CommitTypesEnum.AUD_CLAIM,
+		},
+	}
+	op, _, _, err := providers.NewMockProvider(providerOpts)
+	require.NoError(t, err)
+
+	opts := Opts{
+		altOp: op,
+	}
+
+	err = SignWithGithubActions(opts)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Implements the ideas discussed in #117 — adds a GitHub Actions example, a dedicated integration test workflow, and hardens existing CI pipelines.

## Changes

### New: GitHub Actions Example (`examples/github_actions/`)
- **`example.go`**: End-to-end example using `providers.NewGithubOpFromEnvironment()` to generate and verify a PK Token via GitHub Actions OIDC. Follows the same pattern as the GitLab example.
- **`example_test.go`**: Unit test using a mock provider (runs with `go test ./...`).
- **`example_integration_test.go`**: Integration test behind `//go:build integration` tag. Only runs when explicitly invoked with `-tags integration` in a GitHub Actions environment with `id-token: write` permission.

### New: Integration Workflow (`.github/workflows/integration.yml`)
- Triggers on push to `main` (post-merge only — safe because only reviewed code lands on main).
- Scoped `id-token: write` permission for the integration job only.
- Runs `go test -tags integration -v ./examples/github_actions/`.

### Improved: CI Hardening
- **Job timeouts**: Added `timeout-minutes: 15` to test jobs in both `go.yml` and `staging.yml`.

## Note on `-race` detection

During development, I tested with `go test -race ./...` and found a **pre-existing data race** in `TestClientWithWebChooser` (`client/opkclient_test.go` — race between `StandardOp.defaultRequestTokens` and `StandardOp.ReuseBrowserWindowHook`). Enabling `-race` in CI would catch this and future races, but would block all PRs until the existing race is fixed. I've left it out for now to avoid disruption, but it may be worth addressing in a follow-up.

## Context

PR #117 identified the need for real GitHub Actions OIDC integration testing but was blocked by GitHub's security model (fork PRs cannot request ID tokens). The PR author concluded that an example + post-merge integration test was the best approach (Option 3). This PR implements that approach.

Closes #117