### PR TITLE
feat: Implements client-credentials flow

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -222,18 +222,26 @@ func (o *OpkClient) oidcAuth(
 	if err != nil {
 		return nil, fmt.Errorf("error requesting OIDC tokens from OpenID Provider: %w", err)
 	}
-	idToken := tokens.IDToken
+	providerToken := tokens.IDToken
+	if len(providerToken) == 0 {
+		if _, ok := o.Op.(providers.ClientCredentialsOpenIdProvider); ok && len(tokens.AccessToken) > 0 {
+			providerToken = tokens.AccessToken
+		}
+	}
+	if len(providerToken) == 0 {
+		return nil, fmt.Errorf("provider response missing ID token")
+	}
 	o.refreshToken = tokens.RefreshToken
 	o.accessToken = tokens.AccessToken
 
 	// Sign over the payload from the ID token and client instance claims
-	cicToken, err := cic.Sign(signer, alg, idToken)
+	cicToken, err := cic.Sign(signer, alg, providerToken)
 	if err != nil {
 		return nil, fmt.Errorf("error creating cic token: %w", err)
 	}
 
 	// Combine our ID token and signature over the cic to create our PK Token
-	pkt, err := pktoken.New(idToken, cicToken)
+	pkt, err := pktoken.New(providerToken, cicToken)
 	if err != nil {
 		return nil, fmt.Errorf("error creating PK Token: %w", err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -222,26 +222,18 @@ func (o *OpkClient) oidcAuth(
 	if err != nil {
 		return nil, fmt.Errorf("error requesting OIDC tokens from OpenID Provider: %w", err)
 	}
-	providerToken := tokens.IDToken
-	if len(providerToken) == 0 {
-		if _, ok := o.Op.(providers.ClientCredentialsOpenIdProvider); ok && len(tokens.AccessToken) > 0 {
-			providerToken = tokens.AccessToken
-		}
-	}
-	if len(providerToken) == 0 {
-		return nil, fmt.Errorf("provider response missing ID token")
-	}
+	idToken := tokens.IDToken
 	o.refreshToken = tokens.RefreshToken
 	o.accessToken = tokens.AccessToken
 
 	// Sign over the payload from the ID token and client instance claims
-	cicToken, err := cic.Sign(signer, alg, providerToken)
+	cicToken, err := cic.Sign(signer, alg, idToken)
 	if err != nil {
 		return nil, fmt.Errorf("error creating cic token: %w", err)
 	}
 
 	// Combine our ID token and signature over the cic to create our PK Token
-	pkt, err := pktoken.New(providerToken, cicToken)
+	pkt, err := pktoken.New(idToken, cicToken)
 	if err != nil {
 		return nil, fmt.Errorf("error creating PK Token: %w", err)
 	}

--- a/client/opkclient_test.go
+++ b/client/opkclient_test.go
@@ -339,3 +339,26 @@ func TestDeviceFlow(t *testing.T) {
 	err = c.Op.VerifyIDToken(context.Background(), pkt.OpToken, cic)
 	require.NoError(t, err)
 }
+
+func TestClientCredentialsFlow(t *testing.T) {
+	helloOpOpts := providers.GetDefaultHelloOpOptions()
+	helloOpOpts.ClientID = "OPENPUBKEY-PKTOKEN: app_xejobTKEsDNSRd5vofKB2iay_2rN"
+	helloOpOpts.ClientSecret = "test-client-secret"
+	helloOpOpts.ClientCredentialsFlow = true
+	helloOpOpts.GQSign = true
+	op, err := providers.CreateMockHelloOpWithOpts(helloOpOpts, mocks.UserBrowserInteractionMock{})
+	require.NoError(t, err)
+	require.NotNil(t, op)
+
+	c, err := client.New(op)
+	require.NoError(t, err)
+	pkt, err := c.Auth(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, pkt)
+
+	cic, err := pkt.GetCicValues()
+	require.NoError(t, err)
+
+	err = c.Op.VerifyIDToken(context.Background(), pkt.OpToken, cic)
+	require.NoError(t, err)
+}

--- a/examples/keycloak_client_credentials/example.go
+++ b/examples/keycloak_client_credentials/example.go
@@ -1,0 +1,148 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/goccy/go-json"
+	"github.com/openpubkey/openpubkey/client"
+	"github.com/openpubkey/openpubkey/oidc"
+	"github.com/openpubkey/openpubkey/pktoken"
+	"github.com/openpubkey/openpubkey/providers"
+	"github.com/openpubkey/openpubkey/verifier"
+)
+
+func SignClientCredentials(op client.OpenIdProvider) ([]byte, []byte, error) {
+	opkClient, err := client.New(op)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkt, err := opkClient.Auth(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	msg := []byte("All is discovered - flee at once")
+	signedMsg, err := pkt.NewSignedMessage(msg, opkClient.GetSigner())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pktJSON, err := json.Marshal(pkt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pktJSON, signedMsg, nil
+}
+
+func VerifyClientCredentials(op client.OpenIdProvider, pktJSON []byte, signedMsg []byte) error {
+	pkt := new(pktoken.PKToken)
+	if err := json.Unmarshal(pktJSON, &pkt); err != nil {
+		return err
+	}
+
+	pktVerifier, err := verifier.New(op)
+	if err != nil {
+		return err
+	}
+	if err := pktVerifier.VerifyPKToken(context.Background(), pkt); err != nil {
+		return err
+	}
+
+	msg, err := pkt.VerifySignedMessage(signedMsg)
+	if err != nil {
+		return err
+	}
+
+	claims := new(oidc.OidcClaims)
+	if err := json.Unmarshal(pkt.Payload, claims); err != nil {
+		return err
+	}
+
+	fmt.Printf("Verification successful: sub=%s iss=%s signed the message '%s'\n", claims.Subject, claims.Issuer, string(msg))
+	return nil
+}
+
+func keycloakOpFromEnv() (providers.BrowserOpenIdProvider, error) {
+	issuer := os.Getenv("OPENPUBKEY_KEYCLOAK_ISSUER")
+	if issuer == "" {
+		return nil, fmt.Errorf("OPENPUBKEY_KEYCLOAK_ISSUER is required, for example https://keycloak.example.com/realms/myrealm")
+	}
+
+	clientID := os.Getenv("OPENPUBKEY_KEYCLOAK_CLIENT_ID")
+	if clientID == "" {
+		return nil, fmt.Errorf("OPENPUBKEY_KEYCLOAK_CLIENT_ID is required")
+	}
+
+	opts := providers.GetDefaultStandardOpOptions(issuer, clientID)
+	opts.ClientSecret = os.Getenv("OPENPUBKEY_KEYCLOAK_CLIENT_SECRET")
+
+	if redirectURI := os.Getenv("OPENPUBKEY_KEYCLOAK_REDIRECT_URI"); redirectURI != "" {
+		opts.RemoteRedirectURI = redirectURI
+	}
+
+	return providers.NewStandardOpWithOptions(opts), nil
+}
+
+func keycloakClientCredentialsOpFromEnv() (providers.OpenIdProvider, error) {
+	op, err := keycloakOpFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	stdOp, ok := op.(*providers.StandardOp)
+	if !ok {
+		return nil, fmt.Errorf("configured keycloak provider is not a standard provider")
+	}
+
+	stdOp.ClientCredentialsFlow = true
+	stdOp.GQSign = true
+	if len(stdOp.Scopes) == 0 {
+		stdOp.Scopes = []string{"openid"}
+	}
+
+	return stdOp, nil
+}
+
+// It uses the same environment variables as example.go:
+// OPENPUBKEY_KEYCLOAK_ISSUER
+// OPENPUBKEY_KEYCLOAK_CLIENT_ID
+// OPENPUBKEY_KEYCLOAK_CLIENT_SECRET
+// OPENPUBKEY_KEYCLOAK_REDIRECT_URI
+func main() {
+	op, err := keycloakClientCredentialsOpFromEnv()
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	pktJSON, signedMsg, err := SignClientCredentials(op)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	if err := VerifyClientCredentials(op, pktJSON, signedMsg); err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+}

--- a/examples/keycloak_client_credentials/example_test.go
+++ b/examples/keycloak_client_credentials/example_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/openpubkey/openpubkey/providers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeycloakClientCredentialsExample(t *testing.T) {
+	providerOpts := providers.MockProviderOpts{
+		Issuer:     "mockIssuer",
+		ClientID:   "mockClient-ID",
+		GQSign:     true,
+		NumKeys:    2,
+		CommitType: providers.CommitTypesEnum.GQ_BOUND,
+		VerifierOpts: providers.ProviderVerifierOpts{
+			SkipClientIDCheck: true,
+			GQOnly:            true,
+			CommitType:        providers.CommitTypesEnum.GQ_BOUND,
+		},
+	}
+	op, _, _, err := providers.NewMockProvider(providerOpts)
+	require.NoError(t, err)
+
+	pktJSON, signedMsg, err := SignClientCredentials(op)
+	require.NoError(t, err)
+	require.NotNil(t, pktJSON)
+	require.NotNil(t, signedMsg)
+
+	err = VerifyClientCredentials(op, pktJSON, signedMsg)
+	require.NoError(t, err)
+}

--- a/providers/hello.go
+++ b/providers/hello.go
@@ -60,6 +60,10 @@ type HelloOptions struct {
 	GQSign bool
 	// DeviceFlow denotes if the OIDC Device Flow should be used instead of the authorization code flow.
 	DeviceFlow bool
+	// ClientCredentialsFlow denotes if the OAuth2 client credentials flow should be used.
+	ClientCredentialsFlow bool
+	// ClientSecret is the client secret used for the client credentials flow.
+	ClientSecret string
 	// OpenBrowser denotes if the client's default browser should be opened
 	// automatically when performing the OIDC authorization flow. This value
 	// should typically be set to true, unless performing some headless
@@ -123,6 +127,7 @@ func NewHelloOpWithOptions(opts *HelloOptions) BrowserOpenIdProvider {
 func newHelloOpWithOptions(opts *HelloOptions) *HelloOp {
 	return &HelloOp{
 		clientID:                  opts.ClientID,
+		ClientSecret:              opts.ClientSecret,
 		Scopes:                    opts.Scopes,
 		RedirectURIs:              opts.RedirectURIs,
 		RemoteRedirectURI:         opts.RemoteRedirectURI,
@@ -130,6 +135,7 @@ func newHelloOpWithOptions(opts *HelloOptions) *HelloOp {
 		AccessType:                opts.AccessType,
 		GQSign:                    opts.GQSign,
 		DeviceFlow:                opts.DeviceFlow,
+		ClientCredentialsFlow:     opts.ClientCredentialsFlow,
 		OpenBrowser:               opts.OpenBrowser,
 		HttpClient:                opts.HttpClient,
 		IssuedAtOffset:            opts.IssuedAtOffset,

--- a/providers/mocks/mockop.go
+++ b/providers/mocks/mockop.go
@@ -549,6 +549,13 @@ func (m *MockOp) IssueTokens(req *http.Request) ([]byte, error) {
 			}
 		}
 
+	case "client_credentials":
+		clientSecret := req.FormValue("client_secret")
+		if clientSecret == "" {
+			return nil, fmt.Errorf("missing client_secret in client credentials request")
+		}
+		// No nonce or auth code for client credentials — CIC commitment is added via GQ binding in RequestTokens.
+
 	default:
 		return nil, fmt.Errorf("unsupported grant_type: %s", grantType)
 	}

--- a/providers/op.go
+++ b/providers/op.go
@@ -54,6 +54,12 @@ type RefreshableOpenIdProvider interface {
 	VerifyRefreshedIDToken(ctx context.Context, origIdt []byte, reIdt []byte) error
 }
 
+// Interface for an OpenIdProvider that supports OAuth2 client credentials flow.
+type ClientCredentialsOpenIdProvider interface {
+	OpenIdProvider
+	RequestClientCredentialsTokens(ctx context.Context, scopes []string) (*simpleoidc.Tokens, error)
+}
+
 // Interface for an OpenIdProvider that supports key binding of the ID Token
 type KeyBindingOpenIdProvider interface {
 	OpenIdProvider

--- a/providers/op.go
+++ b/providers/op.go
@@ -57,7 +57,6 @@ type RefreshableOpenIdProvider interface {
 // Interface for an OpenIdProvider that supports OAuth2 client credentials flow.
 type ClientCredentialsOpenIdProvider interface {
 	OpenIdProvider
-	RequestClientCredentialsTokens(ctx context.Context, scopes []string) (*simpleoidc.Tokens, error)
 }
 
 // Interface for an OpenIdProvider that supports key binding of the ID Token

--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -19,7 +19,9 @@ package providers
 import (
 	"context"
 	"crypto"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -33,6 +35,7 @@ import (
 	"github.com/openpubkey/openpubkey/providers/qrcode"
 	"github.com/openpubkey/openpubkey/util"
 	"github.com/sirupsen/logrus"
+	oidcclient "github.com/zitadel/oidc/v3/pkg/client"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	oidchttp "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -84,6 +87,9 @@ type StandardOpOptions struct {
 	GQSign bool
 	// DeviceFlow denotes if the client should use the device flow instead of the standard
 	DeviceFlow bool
+	// ClientCredentialsFlow denotes if the client should use the client credentials
+	// flow to request tokens when RequestTokens is called.
+	ClientCredentialsFlow bool
 	// OpenBrowser denotes if the client's default browser should be opened
 	// automatically when performing the OIDC authorization flow. This value
 	// should typically be set to true, unless performing some headless
@@ -115,13 +121,14 @@ func GetDefaultStandardOpOptions(issuer string, clientID string) *StandardOpOpti
 			"http://localhost:10001/login-callback",
 			"http://localhost:11110/login-callback",
 		},
-		RemoteRedirectURI: "",
-		GQSign:            false,
-		DeviceFlow:        false,
-		OpenBrowser:       true,
-		HttpClient:        nil,
-		IssuedAtOffset:    1 * time.Minute,
-		CallbackHTML:      defaultCallbackHTML,
+		RemoteRedirectURI:     "",
+		GQSign:                false,
+		DeviceFlow:            false,
+		ClientCredentialsFlow: false,
+		OpenBrowser:           true,
+		HttpClient:            nil,
+		IssuedAtOffset:        1 * time.Minute,
+		CallbackHTML:          defaultCallbackHTML,
 	}
 }
 
@@ -140,6 +147,7 @@ func NewStandardOpWithOptions(opts *StandardOpOptions) BrowserOpenIdProvider {
 		RemoteRedirectURI:         opts.RemoteRedirectURI,
 		GQSign:                    opts.GQSign,
 		DeviceFlow:                opts.DeviceFlow,
+		ClientCredentialsFlow:     opts.ClientCredentialsFlow,
 		OpenBrowser:               opts.OpenBrowser,
 		HttpClient:                opts.HttpClient,
 		IssuedAtOffset:            opts.IssuedAtOffset,
@@ -165,6 +173,7 @@ type StandardOp struct {
 	RemoteRedirectURI         string
 	GQSign                    bool
 	DeviceFlow                bool
+	ClientCredentialsFlow     bool
 	OpenBrowser               bool
 	HttpClient                *http.Client
 	IssuedAtOffset            time.Duration
@@ -188,6 +197,7 @@ type StandardOpRefreshable struct {
 var _ OpenIdProvider = (*StandardOp)(nil)
 var _ BrowserOpenIdProvider = (*StandardOp)(nil)
 var _ RefreshableOpenIdProvider = (*StandardOpRefreshable)(nil)
+var _ ClientCredentialsOpenIdProvider = (*StandardOp)(nil)
 
 // NewStandardOp creates a standard OP (OpenID Provider) using the
 // default configuration options and returns a BrowserOpenIdProvider.
@@ -204,6 +214,10 @@ func (s *StandardOp) requestTokens(ctx context.Context, cicHash string) (*simple
 
 	if s.DeviceFlow {
 		return s.deviceFlowRequestTokens(ctx, cicHash)
+	}
+
+	if s.ClientCredentialsFlow {
+		return s.clientCredentialsRequestTokens(ctx, cicHash)
 	}
 
 	return s.defaultRequestTokens(ctx, cicHash)
@@ -381,6 +395,10 @@ func (s *StandardOp) defaultRequestTokens(ctx context.Context, cicHash string) (
 }
 
 func (s *StandardOp) RequestTokens(ctx context.Context, cic *clientinstance.Claims) (*simpleoidc.Tokens, error) {
+	if s.ClientCredentialsFlow && !s.GQSign {
+		return nil, fmt.Errorf("client credentials flow requires GQ signatures")
+	}
+
 	// Define our commitment as the hash of the client instance claims
 	cicHash, err := cic.Hash()
 	if err != nil {
@@ -390,16 +408,106 @@ func (s *StandardOp) RequestTokens(ctx context.Context, cic *clientinstance.Clai
 	if err != nil {
 		return nil, err
 	}
+
+	providerToken := tokens.IDToken
+	if s.ClientCredentialsFlow && len(providerToken) == 0 {
+		providerToken = tokens.AccessToken
+	}
+
 	if s.GQSign {
-		idToken := tokens.IDToken
-		if gqToken, err := CreateGQToken(ctx, idToken, s); err != nil {
-			return nil, err
-		} else {
-			tokens.IDToken = gqToken
-			return tokens, nil
+		if len(providerToken) == 0 {
+			return nil, fmt.Errorf("cannot apply GQ signature: missing provider token")
 		}
+
+		var gqToken []byte
+		if s.ClientCredentialsFlow {
+			gqToken, err = CreateGQBoundToken(ctx, providerToken, s, string(cicHash))
+		} else {
+			gqToken, err = CreateGQToken(ctx, providerToken, s)
+		}
+		if err != nil {
+			return nil, err
+		}
+		tokens.IDToken = gqToken
+		return tokens, nil
 	}
 	return tokens, nil
+}
+
+func (s *StandardOp) RequestClientCredentialsTokens(ctx context.Context, scopes []string) (*simpleoidc.Tokens, error) {
+	if s.ClientSecret == "" {
+		return nil, fmt.Errorf("client credentials flow requires a client secret")
+	}
+
+	httpClient := s.HttpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	discovery, err := oidcclient.Discover(ctx, s.issuer, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover OIDC configuration: %w", err)
+	}
+
+	requestScopes := scopes
+	if len(requestScopes) == 0 {
+		requestScopes = s.Scopes
+	}
+
+	values := url.Values{}
+	values.Set("grant_type", "client_credentials")
+	values.Set("client_id", s.clientID)
+	values.Set("client_secret", s.ClientSecret)
+	if len(requestScopes) > 0 {
+		values.Set("scope", strings.Join(requestScopes, " "))
+	}
+	for k, v := range s.ExtraURLParamOpts {
+		values.Set(k, v)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, discovery.TokenEndpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request client credentials token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResponse struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if tokenResponse.AccessToken == "" && tokenResponse.IDToken == "" {
+		return nil, fmt.Errorf("token endpoint response missing access_token and id_token")
+	}
+
+	return &simpleoidc.Tokens{
+		IDToken:      nilIfEmpty(tokenResponse.IDToken),
+		RefreshToken: nilIfEmpty(tokenResponse.RefreshToken),
+		AccessToken:  nilIfEmpty(tokenResponse.AccessToken),
+	}, nil
+}
+
+func (s *StandardOp) clientCredentialsRequestTokens(ctx context.Context, _ string) (*simpleoidc.Tokens, error) {
+	return s.RequestClientCredentialsTokens(ctx, s.Scopes)
 }
 
 func (s *StandardOp) deviceFlowRequestTokens(ctx context.Context, cicHash string) (*simpleoidc.Tokens, error) {
@@ -553,11 +661,24 @@ func (s *StandardOp) ClientID() string {
 }
 
 func (s *StandardOp) VerifyIDToken(ctx context.Context, idt []byte, cic *clientinstance.Claims) error {
+	commitType := CommitTypesEnum.NONCE_CLAIM
+	gqOnly := false
+	skipClientIDCheck := false
+
+	if s.ClientCredentialsFlow {
+		commitType = CommitTypesEnum.GQ_BOUND
+		gqOnly = true
+		// GQ commitment verification requires skipping strict client-id/audience check.
+		skipClientIDCheck = true
+	}
+
 	vp := NewProviderVerifier(
 		s.issuer,
 		ProviderVerifierOpts{
-			CommitType:        CommitTypesEnum.NONCE_CLAIM,
+			CommitType:        commitType,
 			ClientID:          s.clientID,
+			SkipClientIDCheck: skipClientIDCheck,
+			GQOnly:            gqOnly,
 			DiscoverPublicKey: &s.publicKeyFinder,
 		})
 	return vp.VerifyIDToken(ctx, idt, cic)

--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -409,21 +409,18 @@ func (s *StandardOp) RequestTokens(ctx context.Context, cic *clientinstance.Clai
 		return nil, err
 	}
 
-	providerToken := tokens.IDToken
-	if s.ClientCredentialsFlow && len(providerToken) == 0 {
-		providerToken = tokens.AccessToken
-	}
+	idToken := tokens.IDToken
 
 	if s.GQSign {
-		if len(providerToken) == 0 {
-			return nil, fmt.Errorf("cannot apply GQ signature: missing provider token")
+		if len(idToken) == 0 {
+			return nil, fmt.Errorf("cannot apply GQ signature: missing id token")
 		}
 
 		var gqToken []byte
 		if s.ClientCredentialsFlow {
-			gqToken, err = CreateGQBoundToken(ctx, providerToken, s, string(cicHash))
+			gqToken, err = CreateGQBoundToken(ctx, idToken, s, string(cicHash))
 		} else {
-			gqToken, err = CreateGQToken(ctx, providerToken, s)
+			gqToken, err = CreateGQToken(ctx, idToken, s)
 		}
 		if err != nil {
 			return nil, err
@@ -434,7 +431,9 @@ func (s *StandardOp) RequestTokens(ctx context.Context, cic *clientinstance.Clai
 	return tokens, nil
 }
 
-func (s *StandardOp) RequestClientCredentialsTokens(ctx context.Context, scopes []string) (*simpleoidc.Tokens, error) {
+func (s *StandardOp) clientCredentialsRequestTokens(ctx context.Context, _ string) (*simpleoidc.Tokens, error) {
+	scopes := s.Scopes
+
 	if s.ClientSecret == "" {
 		return nil, fmt.Errorf("client credentials flow requires a client secret")
 	}
@@ -495,8 +494,8 @@ func (s *StandardOp) RequestClientCredentialsTokens(ctx context.Context, scopes 
 		return nil, fmt.Errorf("failed to decode token response: %w", err)
 	}
 
-	if tokenResponse.AccessToken == "" && tokenResponse.IDToken == "" {
-		return nil, fmt.Errorf("token endpoint response missing access_token and id_token")
+	if tokenResponse.IDToken == "" {
+		return nil, fmt.Errorf("token endpoint response missing id_token")
 	}
 
 	return &simpleoidc.Tokens{
@@ -504,10 +503,6 @@ func (s *StandardOp) RequestClientCredentialsTokens(ctx context.Context, scopes 
 		RefreshToken: nilIfEmpty(tokenResponse.RefreshToken),
 		AccessToken:  nilIfEmpty(tokenResponse.AccessToken),
 	}, nil
-}
-
-func (s *StandardOp) clientCredentialsRequestTokens(ctx context.Context, _ string) (*simpleoidc.Tokens, error) {
-	return s.RequestClientCredentialsTokens(ctx, s.Scopes)
 }
 
 func (s *StandardOp) deviceFlowRequestTokens(ctx context.Context, cicHash string) (*simpleoidc.Tokens, error) {

--- a/providers/standard_provider_test.go
+++ b/providers/standard_provider_test.go
@@ -21,10 +21,12 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/openpubkey/openpubkey/oidc"
 	"github.com/openpubkey/openpubkey/providers/mocks"
 	"github.com/openpubkey/openpubkey/util"
 	"github.com/stretchr/testify/require"
@@ -371,4 +373,99 @@ func TestCallbackHTMLProviderSpecific(t *testing.T) {
 		require.Equal(t, customHTML, opUnwrapped.CallbackHTML,
 			"CallbackHTML should be set correctly from HelloOptions")
 	})
+}
+
+func TestClientCredentialsWithGQCommitment(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	issuer := server.URL + "/realms/test"
+
+	mockBackend, err := mocks.NewMockProviderBackend(issuer, "RS256", 1)
+	require.NoError(t, err)
+	signer, keyID, record := mockBackend.RandomSigningKey()
+
+	idTemplate := &mocks.IDTokenTemplate{
+		CommitFunc: mocks.NoClaimCommit,
+		Issuer:     issuer,
+		NoNonce:    true,
+		Aud:        AudPrefixForGQCommitment + "client-credentials",
+		KeyID:      keyID,
+		NoKeyID:    false,
+		Alg:        record.Alg,
+		NoAlg:      false,
+		SigningKey: signer,
+	}
+	tok, err := idTemplate.IssueTokens()
+	require.NoError(t, err)
+
+	jwksJSON, err := mockBackend.GetJwks()
+	require.NoError(t, err)
+
+	mux.HandleFunc("/realms/test/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":         issuer,
+			"token_endpoint": server.URL + "/token",
+			"jwks_uri":       server.URL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksJSON)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "client_credentials", r.FormValue("grant_type"))
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": string(tok.IDToken),
+			"token_type":   "Bearer",
+			"expires_in":   300,
+		})
+	})
+
+	opts := GetDefaultStandardOpOptions(issuer, "test-client-id")
+	opts.ClientSecret = "test-client-secret"
+	opts.HttpClient = server.Client()
+	opts.ClientCredentialsFlow = true
+	opts.GQSign = true
+
+	op := NewStandardOpWithOptions(opts)
+	opStd, ok := op.(*StandardOp)
+	require.True(t, ok)
+
+	cic := GenCIC(t)
+	tokens, err := opStd.RequestTokens(context.Background(), cic)
+	require.NoError(t, err)
+	require.NotEmpty(t, tokens.AccessToken)
+	require.NotEmpty(t, tokens.IDToken)
+	require.NotEqual(t, string(tokens.AccessToken), string(tokens.IDToken))
+
+	jwt, err := oidc.NewJwt(tokens.IDToken)
+	require.NoError(t, err)
+	require.Equal(t, "GQ256", jwt.GetSignature().GetProtectedClaims().Alg)
+
+	err = opStd.VerifyIDToken(context.Background(), tokens.IDToken, cic)
+	require.NoError(t, err)
+
+	wrongCIC := GenCIC(t)
+	err = opStd.VerifyIDToken(context.Background(), tokens.IDToken, wrongCIC)
+	require.ErrorContains(t, err, "commitment claim doesn't match")
+}
+
+func TestClientCredentialsRequiresGQSign(t *testing.T) {
+	issuer := "https://issuer.example"
+	opts := GetDefaultStandardOpOptions(issuer, "test-client-id")
+	opts.ClientSecret = "test-client-secret"
+	opts.ClientCredentialsFlow = true
+	opts.GQSign = false
+
+	op := NewStandardOpWithOptions(opts)
+	opStd, ok := op.(*StandardOp)
+	require.True(t, ok)
+
+	_, err := opStd.RequestTokens(context.Background(), GenCIC(t))
+	require.ErrorContains(t, err, "client credentials flow requires GQ signatures")
 }

--- a/providers/standard_provider_test.go
+++ b/providers/standard_provider_test.go
@@ -420,9 +420,9 @@ func TestClientCredentialsWithGQCommitment(t *testing.T) {
 		require.Equal(t, "client_credentials", r.FormValue("grant_type"))
 
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token": string(tok.IDToken),
-			"token_type":   "Bearer",
-			"expires_in":   300,
+			"id_token":   string(tok.IDToken),
+			"token_type": "Bearer",
+			"expires_in": 300,
 		})
 	})
 
@@ -439,7 +439,6 @@ func TestClientCredentialsWithGQCommitment(t *testing.T) {
 	cic := GenCIC(t)
 	tokens, err := opStd.RequestTokens(context.Background(), cic)
 	require.NoError(t, err)
-	require.NotEmpty(t, tokens.AccessToken)
 	require.NotEmpty(t, tokens.IDToken)
 	require.NotEqual(t, string(tokens.AccessToken), string(tokens.IDToken))
 


### PR DESCRIPTION
Proposal for an implementation of client credentials flow.

Here is an example of a credential client requests with the response:

```
BASIC="$OPENPUBKEY_KEYCLOAK_CLIENT_ID:$OPENPUBKEY_KEYCLOAK_CLIENT_SECRET" curl -X POST "$OPENPUBKEY_KEYCLOAK_ISSUER/protocol/openid-connect/token" \
              -H "Content-Type: application/x-www-form-urlencoded" \
              -d "grant_type=client_credentials" \
              -d "scope=openid" \
              -d "client_id=$OPENPUBKEY_KEYCLOAK_CLIENT_ID" \
              -d "client_secret=$OPENPUBKEY_KEYCLOAK_CLIENT_SECRET" | jq
```

```json
{
  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1YWRlcUQ5WTZWUS1qMmFoZ3JvRktHSU1GdTRYaEJVd3lvdGpEejBKY2RJIn0.eyJleHAiOjE3ODAwNDIzNzMsImlhdCI6MTc4MDA0MjMxMywianRpIjoiZmNhZmM4MDktMjg1NC00ZGE4LWI4NjktZWY1MGJhNDIxYjdlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZjhlODlmMmMtODMyYS00NmIyLTg4NjctOGFiZjYxNTE1MGZiIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiT1BFTlBVQktFWS1QS1RPS0VOOiB0ZXN0LW0ybSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiLyoiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImRlZmF1bHQtcm9sZXMtbWFzdGVyIiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImNsaWVudEhvc3QiOiIxNzIuMjAuMC4xIiwicHJlZmVycmVkX3VzZXJuYW1lIjoic2VydmljZS1hY2NvdW50LW9wZW5wdWJrZXktcGt0b2tlbjogdGVzdC1tMm0iLCJjbGllbnRBZGRyZXNzIjoiMTcyLjIwLjAuMSIsImNsaWVudF9pZCI6Ik9QRU5QVUJLRVktUEtUT0tFTjogdGVzdC1tMm0ifQ.mxDD1AHXA4hogC52CacPAq2IS_SuR8lNQwDA2LrdmTQHxPtpiZrdLuVzdTCO9BzZh1Vw4pFCvU-l92bY1JujzE8rDQk21zIalXJsNegGwX1fCPJMVdQiXC-YDdvtsGey37ES95anPK3oXfPBykoaWfAgeEUzi9orGv1yaaJqEvmBjhvGZXTC_rCuntftTJ9dqkKyvjpGZ84cu28I5_7e1JrEgp-ev5gyZWOszi1nr_H-j_OG3piiQCVjJW9vfhSasFNmjX8Vijsm_VX9awzbPeTLD2cS0StFI0LUVfg0HIr7WG2lfbLyGD-uR9Ab63n-noVA3D2TdylLKoYSaYgsag",
  "expires_in": 60,
  "refresh_expires_in": 0,
  "token_type": "Bearer",
  "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1YWRlcUQ5WTZWUS1qMmFoZ3JvRktHSU1GdTRYaEJVd3lvdGpEejBKY2RJIn0.eyJleHAiOjE3ODAwNDIzNzMsImlhdCI6MTc4MDA0MjMxMywiYXV0aF90aW1lIjowLCJqdGkiOiJkMzBkZWExNi0zMTE1LTRjNGEtOGY3ZS0yYWEzMzE2NmY1N2IiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL21hc3RlciIsImF1ZCI6Ik9QRU5QVUJLRVktUEtUT0tFTjogdGVzdC1tMm0iLCJzdWIiOiJmOGU4OWYyYy04MzJhLTQ2YjItODg2Ny04YWJmNjE1MTUwZmIiLCJ0eXAiOiJJRCIsImF6cCI6Ik9QRU5QVUJLRVktUEtUT0tFTjogdGVzdC1tMm0iLCJhdF9oYXNoIjoid0JzUlhpdmN0VGpGTmZGUVBXRlhHZyIsImFjciI6IjEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImNsaWVudEhvc3QiOiIxNzIuMjAuMC4xIiwicHJlZmVycmVkX3VzZXJuYW1lIjoic2VydmljZS1hY2NvdW50LW9wZW5wdWJrZXktcGt0b2tlbjogdGVzdC1tMm0iLCJjbGllbnRBZGRyZXNzIjoiMTcyLjIwLjAuMSIsImNsaWVudF9pZCI6Ik9QRU5QVUJLRVktUEtUT0tFTjogdGVzdC1tMm0ifQ.Op4IKlb9_1q8a4wrKXI_joBFsduUPGtc_3qsEp5RMrtGRwZDt69LqE9TcMX41vGY7hOrzfmXws_zm4N-MVYJdC0x_gRFUK3dLxgogjyenOQonBeIQ9rS89nxuKdNVF2vetMfkFqetP9oWUbRjeME-Tez3cSUCpw3lxvFmjf4kXAL9Xc24TqjRuzdPgj8GyGLgfI_0gmnnh_Gqq_uqQqBTrGEujDWMoFlqUN9oEzMeUxPiPu-QeY4vPTDRbOiIQxXjISNMgmX14-J9FA7lHUZtfeU1eL7_mTNmHoiwTIHqQjkH3hWndKDFWgXR2r0YYeBctmeBCYqlzB4jRf_VGZQyg",
  "not-before-policy": 0,
  "scope": "openid email profile"
}
```