### PR TITLE
fix: support RSA exponents other than 65537 for GQ signatures

### DIFF
--- a/gq/gq.go
+++ b/gq/gq.go
@@ -135,6 +135,9 @@ func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int) (SignerV
 	if publicKey.E < 3 || publicKey.E%2 == 0 {
 		return nil, fmt.Errorf("unsupported RSA public key exponent: %d, must be odd and at least 3", publicKey.E)
 	}
+	if securityParameter <= 0 {
+		return nil, fmt.Errorf("security parameter must be positive, got %d", securityParameter)
+	}
 	n, v, nBytes, vBytes, err := parsePublicKey(publicKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse RSA public key: %w", err)

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -132,8 +132,8 @@ func New256SignerVerifier(publicKey *rsa.PublicKey) (SignerVerifier, error) {
 //
 // The securityParameter parameter is the level of desired security in bits. 256 is recommended.
 func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int) (SignerVerifier, error) {
-	if publicKey.E < 3 {
-		return nil, fmt.Errorf("unsupported RSA public key exponent: %d, must be at least 3", publicKey.E)
+	if publicKey.E < 3 || publicKey.E%2 == 0 {
+		return nil, fmt.Errorf("unsupported RSA public key exponent: %d, must be odd and at least 3", publicKey.E)
 	}
 	n, v, nBytes, vBytes, err := parsePublicKey(publicKey)
 	if err != nil {

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"math/bits"
 
 	"filippo.io/bigmod"
 	"github.com/lestrrat-go/jwx/v3/jwa"
@@ -131,15 +132,19 @@ func New256SignerVerifier(publicKey *rsa.PublicKey) (SignerVerifier, error) {
 //
 // The securityParameter parameter is the level of desired security in bits. 256 is recommended.
 func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int) (SignerVerifier, error) {
-	if publicKey.E != 65537 {
-		// Danger: Currently it is unsafe to use this library with a RSA exponent other than 65537.
-		// This issue is being tracked in https://github.com/openpubkey/openpubkey/issues/230
-		return nil, fmt.Errorf("only 65537 is currently supported, unsupported RSA public key exponent: %d", publicKey.E)
+	if publicKey.E < 3 {
+		return nil, fmt.Errorf("unsupported RSA public key exponent: %d, must be at least 3", publicKey.E)
 	}
 	n, v, nBytes, vBytes, err := parsePublicKey(publicKey)
-	t := securityParameter / (vBytes * 8)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RSA public key: %w", err)
+	}
+	// Each GQ1 round provides floor(log2(E)) bits of soundness. Compute t = ceil(securityParameter / floor(log2(E))).
+	// bits.Len(uint(E)) - 1 equals floor(log2(E)) exactly for all E >= 2, avoiding floating-point imprecision.
+	bitsPerRound := bits.Len(uint(publicKey.E)) - 1
+	t := (securityParameter + bitsPerRound - 1) / bitsPerRound
 
-	return &signerVerifier{n, v, nBytes, vBytes, t}, err
+	return &signerVerifier{n, v, nBytes, vBytes, t}, nil
 }
 
 func parsePublicKey(publicKey *rsa.PublicKey) (n *bigmod.Modulus, v *big.Int, nBytes int, vBytes int, err error) {

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -155,15 +155,29 @@ func TestVerifyModifiedGqPayload(t *testing.T) {
 
 }
 
-func TestRejectUnsupportedPublicKey(t *testing.T) {
-	oidcPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	oidcPrivKey.E = 3
-	oidcPubKey := &oidcPrivKey.PublicKey
-
-	signerVerifier, err := NewSignerVerifier(oidcPubKey, 256)
-	require.ErrorContains(t, err, "only 65537 is currently supported, unsupported RSA public key exponent")
-	require.Nil(t, signerVerifier)
+func TestTComputationForSoundness(t *testing.T) {
+	// t = ceil(256 / floor(log2(E))), computed via integer arithmetic.
+	tests := []struct {
+		name     string
+		exponent int
+		wantT    int
+	}{
+		{"E=65537 standard", 65537, 16},  // ceil(256 / 16) = 16
+		{"E=3 small exponent", 3, 256},   // ceil(256 / 1) = 256
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			require.NoError(t, err)
+			key.E = tt.exponent
+			sv, err := NewSignerVerifier(&key.PublicKey, 256)
+			require.NoError(t, err)
+			svImpl := sv.(*signerVerifier)
+			if svImpl.t != tt.wantT {
+				t.Errorf("NewSignerVerifier(E=%d, securityParam=256).t = %d, want %d", tt.exponent, svImpl.t, tt.wantT)
+			}
+		})
+	}
 }
 
 func modifyTokenPayload(token []byte, audience string) ([]byte, error) {

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -163,6 +163,9 @@ func TestTComputationForSoundness(t *testing.T) {
 		wantT    int
 	}{
 		{"E=65537 standard", 65537, 16}, // ceil(256 / 16) = 16
+		{"E=257", 257, 32},              // ceil(256 / 8) = 32
+		{"E=17", 17, 64},                // ceil(256 / 4) = 64
+		{"E=5", 5, 128},                 // ceil(256 / 2) = 128
 		{"E=3 small exponent", 3, 256},  // ceil(256 / 1) = 256
 	}
 	for _, tt := range tests {

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -155,6 +155,21 @@ func TestVerifyModifiedGqPayload(t *testing.T) {
 
 }
 
+func TestNewSignerVerifierRejectsInvalidExponents(t *testing.T) {
+	for _, e := range []int{0, 1, 2, 4, 6} {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		key.E = e
+		sv, err := NewSignerVerifier(&key.PublicKey, 256)
+		if err == nil {
+			t.Errorf("NewSignerVerifier(E=%d) should have returned an error", e)
+		}
+		if sv != nil {
+			t.Errorf("NewSignerVerifier(E=%d) should have returned nil SignerVerifier", e)
+		}
+	}
+}
+
 func TestTComputationForSoundness(t *testing.T) {
 	// t = ceil(256 / floor(log2(E))), computed via integer arithmetic.
 	tests := []struct {

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -162,8 +162,8 @@ func TestTComputationForSoundness(t *testing.T) {
 		exponent int
 		wantT    int
 	}{
-		{"E=65537 standard", 65537, 16},  // ceil(256 / 16) = 16
-		{"E=3 small exponent", 3, 256},   // ceil(256 / 1) = 256
+		{"E=65537 standard", 65537, 16}, // ceil(256 / 16) = 16
+		{"E=3 small exponent", 3, 256},  // ceil(256 / 1) = 256
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -200,7 +200,7 @@ func TestTComputationForSoundness(t *testing.T) {
 }
 
 func TestSignVerifyJWTWithExponentE3(t *testing.T) {
-	privKey := generateRSAKeyWithExponent(t, 2048, 3)
+	privKey := generateTestRSAKeyWithExponent(t, 2048, 3)
 
 	idToken, err := createOIDCToken(privKey, "test")
 	require.NoError(t, err)
@@ -215,14 +215,17 @@ func TestSignVerifyJWTWithExponentE3(t *testing.T) {
 	require.True(t, ok, "GQ sign+verify with E=3 failed")
 }
 
-// generateRSAKeyWithExponent generates an RSA key with the given public exponent.
+// generateTestRSAKeyWithExponent generates an RSA key with the given public exponent.
 // rsa.GenerateKey always uses 65537, so this constructs the key manually.
 // e must be odd and >= 3; even or small values will never satisfy gcd(e, phi)=1 and loop forever.
-func generateRSAKeyWithExponent(t *testing.T, bits, e int) *rsa.PrivateKey {
+// Intended for generating test keys for unittests.	DO NOT call this function if security is desired!
+func generateTestRSAKeyWithExponent(t *testing.T, bits, e int) *rsa.PrivateKey {
 	t.Helper()
 	if e < 3 || e%2 == 0 {
 		t.Fatalf("generateRSAKeyWithExponent: e=%d is invalid; must be odd and >= 3", e)
 	}
+	// DO NOT use the code below in settings where security is desired.
+	// This code is for generating test data, not secure RSA keys
 	bigE := big.NewInt(int64(e))
 	one := big.NewInt(1)
 	for {

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -20,6 +20,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
@@ -156,17 +158,17 @@ func TestVerifyModifiedGqPayload(t *testing.T) {
 }
 
 func TestNewSignerVerifierRejectsInvalidExponents(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	// 0, 1, 2 are rejected by E < 3; 4 and 6 are rejected by E%2 == 0.
 	for _, e := range []int{0, 1, 2, 4, 6} {
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
-		require.NoError(t, err)
-		key.E = e
-		sv, err := NewSignerVerifier(&key.PublicKey, 256)
-		if err == nil {
-			t.Errorf("NewSignerVerifier(E=%d) should have returned an error", e)
-		}
-		if sv != nil {
-			t.Errorf("NewSignerVerifier(E=%d) should have returned nil SignerVerifier", e)
-		}
+		t.Run(fmt.Sprintf("E=%d", e), func(t *testing.T) {
+			key.E = e
+			sv, err := NewSignerVerifier(&key.PublicKey, 256)
+			require.Error(t, err, "NewSignerVerifier(E=%d) should have returned an error", e)
+			require.ErrorContains(t, err, "unsupported RSA public key exponent")
+			require.Nil(t, sv)
+		})
 	}
 }
 
@@ -183,18 +185,71 @@ func TestTComputationForSoundness(t *testing.T) {
 		{"E=5", 5, 128},                 // ceil(256 / 2) = 128
 		{"E=3 small exponent", 3, 256},  // ceil(256 / 1) = 256
 	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			key, err := rsa.GenerateKey(rand.Reader, 2048)
-			require.NoError(t, err)
 			key.E = tt.exponent
 			sv, err := NewSignerVerifier(&key.PublicKey, 256)
 			require.NoError(t, err)
-			svImpl := sv.(*signerVerifier)
-			if svImpl.t != tt.wantT {
-				t.Errorf("NewSignerVerifier(E=%d, securityParam=256).t = %d, want %d", tt.exponent, svImpl.t, tt.wantT)
-			}
+			svImpl, ok := sv.(*signerVerifier)
+			require.True(t, ok, "expected *signerVerifier concrete type, got %T", sv)
+			require.Equal(t, tt.wantT, svImpl.t, "NewSignerVerifier(E=%d, securityParam=256).t", tt.exponent)
 		})
+	}
+}
+
+func TestSignVerifyJWTWithExponentE3(t *testing.T) {
+	privKey := generateRSAKeyWithExponent(t, 2048, 3)
+
+	idToken, err := createOIDCToken(privKey, "test")
+	require.NoError(t, err)
+
+	sv, err := NewSignerVerifier(&privKey.PublicKey, 256)
+	require.NoError(t, err)
+
+	gqToken, err := sv.SignJWT(idToken)
+	require.NoError(t, err)
+
+	ok := sv.VerifyJWT(gqToken)
+	require.True(t, ok, "GQ sign+verify with E=3 failed")
+}
+
+// generateRSAKeyWithExponent generates an RSA key with the given public exponent.
+// rsa.GenerateKey always uses 65537, so this constructs the key manually.
+// e must be odd and >= 3; even or small values will never satisfy gcd(e, phi)=1 and loop forever.
+func generateRSAKeyWithExponent(t *testing.T, bits, e int) *rsa.PrivateKey {
+	t.Helper()
+	if e < 3 || e%2 == 0 {
+		t.Fatalf("generateRSAKeyWithExponent: e=%d is invalid; must be odd and >= 3", e)
+	}
+	bigE := big.NewInt(int64(e))
+	one := big.NewInt(1)
+	for {
+		p, err := rand.Prime(rand.Reader, bits/2)
+		require.NoError(t, err)
+		q, err := rand.Prime(rand.Reader, bits/2)
+		require.NoError(t, err)
+
+		pMinus1 := new(big.Int).Sub(p, one)
+		qMinus1 := new(big.Int).Sub(q, one)
+		phi := new(big.Int).Mul(pMinus1, qMinus1)
+
+		gcd := new(big.Int).GCD(nil, nil, bigE, phi)
+		if gcd.Cmp(one) != 0 {
+			continue
+		}
+
+		n := new(big.Int).Mul(p, q)
+		d := new(big.Int).ModInverse(bigE, phi)
+
+		key := &rsa.PrivateKey{
+			PublicKey: rsa.PublicKey{N: n, E: e},
+			D:         d,
+			Primes:    []*big.Int{p, q},
+		}
+		key.Precompute()
+		return key
 	}
 }
 


### PR DESCRIPTION
Fixes #230.

The `t` parameter was computed incorrectly for exponents other than 65537, giving far fewer rounds than the security parameter requires. This uses `floor(log2(E))` bits per round and removes the 65537-only guard.