### PR TITLE
fix: avoid panic on array aud in GQCommitment verification

### DIFF
--- a/providers/providerverifier.go
+++ b/providers/providerverifier.go
@@ -219,6 +219,10 @@ func (v *DefaultProviderVerifier) verifyCommitment(idt *oidc.Jwt, cic *clientins
 		if !ok {
 			return fmt.Errorf("require audience claim prefix missing in PK Token's GQCommitment")
 		}
+		audStr, ok := aud.(string)
+		if !ok {
+			return fmt.Errorf("audience claim in PK Token's GQCommitment must be a string, got %T", aud)
+		}
 
 		// To prevent attacks where a attacker takes someone else's ID Token
 		// and turns it into a PK Token using a GQCommitment, we require that
@@ -227,9 +231,9 @@ func (v *DefaultProviderVerifier) verifyCommitment(idt *oidc.Jwt, cic *clientins
 		// claim with a configured prefix (default: "OPENPUBKEY-PKTOKEN:").
 		// We reject all GQ commitment PK Tokens that don't have this prefix
 		// in the aud claim.
-		if _, ok := strings.CutPrefix(aud.(string), v.options.GQAudiencePrefix); !ok {
+		if _, ok := strings.CutPrefix(audStr, v.options.GQAudiencePrefix); !ok {
 			return fmt.Errorf("audience claim in PK Token's GQCommitment must be prefixed by (%s), got (%s) instead",
-				v.options.GQAudiencePrefix, aud.(string))
+				v.options.GQAudiencePrefix, audStr)
 		}
 
 		// Get the commitment from the GQ signed protected header claim "cic" in the ID Token

--- a/providers/providerverifier_test.go
+++ b/providers/providerverifier_test.go
@@ -426,3 +426,53 @@ func TestRejectUnexpectedAlg(t *testing.T) {
 	err = pv.VerifyIDToken(context.Background(), idTokenBadAlgPh, cic)
 	require.Error(t, err)
 }
+
+func TestGQCommitmentArrayAudReturnsError(t *testing.T) {
+	issuer := "https://gitlab.example.com"
+	clientID := "test-client"
+
+	idtTemplate := mocks.IDTokenTemplate{
+		Issuer:               issuer,
+		Nonce:                "empty",
+		Aud:                  AudPrefixForGQCommitment,
+		Alg:                  "RS256",
+		ExtraClaims:          map[string]any{"aud": []any{AudPrefixForGQCommitment + "abc", "other"}},
+		ExtraProtectedClaims: map[string]any{},
+		CommitFunc:           mocks.NoClaimCommit,
+	}
+	cic := GenCICExtra(t, map[string]any{})
+
+	op, backendMock, _, err := NewMockProvider(MockProviderOpts{
+		Issuer:     issuer,
+		Alg:        "RS256",
+		ClientID:   clientID,
+		GQSign:     true,
+		NumKeys:    2,
+		CommitType: CommitTypesEnum.GQ_BOUND,
+		VerifierOpts: ProviderVerifierOpts{
+			CommitType:        CommitTypesEnum.GQ_BOUND,
+			ClientID:          clientID,
+			SkipClientIDCheck: true,
+			GQOnly:            true,
+		},
+	})
+	require.NoError(t, err)
+	opSignKey, keyID, _ := backendMock.RandomSigningKey()
+	idtTemplate.KeyID = keyID
+	idtTemplate.SigningKey = opSignKey
+	backendMock.SetIDTokenTemplate(&idtTemplate)
+
+	tokens, err := op.RequestTokens(context.Background(), cic)
+	require.NoError(t, err)
+
+	pv := NewProviderVerifier(issuer, ProviderVerifierOpts{
+		CommitType:        CommitTypesEnum.GQ_BOUND,
+		DiscoverPublicKey: &backendMock.PublicKeyFinder,
+		GQOnly:            true,
+		SkipClientIDCheck: true,
+	})
+
+	// An array aud is valid per RFC 7519; verification must return an error, not panic.
+	err = pv.VerifyIDToken(context.Background(), tokens.IDToken, cic)
+	require.ErrorContains(t, err, "must be a string")
+}


### PR DESCRIPTION
`verifyCommitment` reads `aud` from a raw `map[string]any` and asserts `aud.(string)` (`providers/providerverifier.go:230`). RFC 7519 allows `aud` to be a string array, so a GQ-signed PK token whose ID token carries an array `aud` panics the verifier.

`oidc.OidcClaims.UnmarshalJSON` already handles array `aud`, so only the GQCommitment path is affected. This asserts the type and returns an error instead. `TestGQCommitmentArrayAudReturnsError` panics before the change and passes after.
