### PR TITLE
[fix] Changes GQ signature to cover GQ protected header 

### DIFF
--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -171,6 +171,48 @@ func TestVerifyModifiedGqPayload(t *testing.T) {
 
 }
 
+func TestVerifyModifiedGqProtectedHeaderCic(t *testing.T) {
+	oidcPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	oidcPubKey := &oidcPrivKey.PublicKey
+
+	idToken, err := createOIDCToken(oidcPrivKey, "test")
+	require.NoError(t, err)
+
+	signerVerifier, err := NewSignerVerifier(oidcPubKey, 256)
+	require.NoError(t, err)
+	gqToken, err := signerVerifier.SignJWT(idToken, WithExtraClaim("cic", "original-commitment"))
+	require.NoError(t, err)
+
+	modifiedToken, err := modifyTokenProtectedHeaderClaim(gqToken, "cic", "attacker-commitment")
+	require.NoError(t, err)
+
+	ok := signerVerifier.VerifyJWT(modifiedToken)
+	require.False(t, ok, "verify passed for tampered cic")
+}
+
+func TestVerifyModifiedGqProtectedHeaderJkt(t *testing.T) {
+	oidcPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	oidcPubKey := &oidcPrivKey.PublicKey
+
+	idToken, err := createOIDCToken(oidcPrivKey, "test")
+	require.NoError(t, err)
+
+	signerVerifier, err := NewSignerVerifier(oidcPubKey, 256)
+	require.NoError(t, err)
+	gqToken, err := signerVerifier.SignJWT(idToken, WithExtraClaim("jkt", "original-thumbprint"))
+	require.NoError(t, err)
+
+	modifiedToken, err := modifyTokenProtectedHeaderClaim(gqToken, "jkt", "attacker-thumbprint")
+	require.NoError(t, err)
+
+	ok := signerVerifier.VerifyJWT(modifiedToken)
+	require.False(t, ok, "verify passed for tampered jkt")
+}
+
 func TestNewSignerVerifierRejectsInvalidExponents(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
@@ -286,6 +328,32 @@ func modifyTokenPayload(token []byte, audience string) ([]byte, error) {
 		return nil, err
 	}
 	newToken := util.JoinJWTSegments(headers, util.Base64EncodeForJWT(modifiedPayload), signature)
+	return newToken, nil
+}
+
+func modifyTokenProtectedHeaderClaim(token []byte, claimKey string, newValue string) ([]byte, error) {
+	headersB64, payload, signature, err := jws.SplitCompact(token)
+	if err != nil {
+		return nil, err
+	}
+
+	headersJSON, err := util.Base64DecodeForJWT(headersB64)
+	if err != nil {
+		return nil, err
+	}
+
+	var headers map[string]any
+	if err := json.Unmarshal(headersJSON, &headers); err != nil {
+		return nil, err
+	}
+	headers[claimKey] = newValue
+
+	modifiedHeadersJSON, err := json.Marshal(headers)
+	if err != nil {
+		return nil, err
+	}
+
+	newToken := util.JoinJWTSegments(util.Base64EncodeForJWT(modifiedHeadersJSON), payload, signature)
 	return newToken, nil
 }
 

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -106,8 +106,6 @@ func (sv *signerVerifier) SignJWT(jwt []byte, opts ...Opts) ([]byte, error) {
 		return nil, err
 	}
 
-	signingPayload := util.JoinJWTSegments(origHeaders, payload)
-
 	headers := jws.NewHeaders()
 	err = headers.Set(jws.AlgorithmKey, jose.GQ256)
 	if err != nil {
@@ -150,7 +148,9 @@ func (sv *signerVerifier) SignJWT(jwt []byte, opts ...Opts) ([]byte, error) {
 
 	defer private.Destroy()
 
-	gqSig, err := sv.Sign(private.Bytes(), signingPayload)
+	// Sign over the new outer header so jkt/cic/extra claims are bound.
+	gqMessage := util.JoinJWTSegments(headersEnc, payload)
+	gqSig, err := sv.Sign(private.Bytes(), gqMessage)
 	if err != nil {
 		return nil, err
 	}

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -148,7 +148,7 @@ func (sv *signerVerifier) SignJWT(jwt []byte, opts ...Opts) ([]byte, error) {
 
 	defer private.Destroy()
 
-	// Sign over the new outer header so jkt/cic/extra claims are bound.
+	// Sign over the new GQ protected header so jkt/cic/extra claims are covered by the GQ signature and can not be altered without breaking signature verification
 	gqMessage := util.JoinJWTSegments(headersEnc, payload)
 	gqSig, err := sv.Sign(private.Bytes(), gqMessage)
 	if err != nil {

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -101,8 +101,7 @@ func (sv *signerVerifier) VerifyJWT(jwt []byte) bool {
 		return false
 	}
 
-	// identity (from kid) forms G and must match the signer's RSA key;
-	// message covers the outer header so tampering it fails verification.
+	// This ensures GQ signature covers the GQ protected header so an attacker can not alter the values in the GQ protected header
 	identity := util.JoinJWTSegments(origHeaders, payload)
 	message := util.JoinJWTSegments(gqHeaders, payload)
 

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -96,14 +96,17 @@ func (sv *signerVerifier) VerifyJWT(jwt []byte) bool {
 		return false
 	}
 
-	_, payload, signature, err := jws.SplitCompact(jwt)
+	gqHeaders, payload, signature, err := jws.SplitCompact(jwt)
 	if err != nil {
 		return false
 	}
 
-	signingPayload := util.JoinJWTSegments(origHeaders, payload)
+	// identity (from kid) forms G and must match the signer's RSA key;
+	// message covers the outer header so tampering it fails verification.
+	identity := util.JoinJWTSegments(origHeaders, payload)
+	message := util.JoinJWTSegments(gqHeaders, payload)
 
-	return sv.Verify(signature, signingPayload, signingPayload)
+	return sv.Verify(signature, identity, message)
 }
 
 func (sv *signerVerifier) decodeProof(s []byte) (R, S []byte, err error) {

--- a/providers/providerverifier.go
+++ b/providers/providerverifier.go
@@ -236,7 +236,7 @@ func (v *DefaultProviderVerifier) verifyCommitment(idt *oidc.Jwt, cic *clientins
 				v.options.GQAudiencePrefix, audStr)
 		}
 
-		// "cic" is in the outer header, which the GQ signature binds.
+		// Get the commitment from the GQ signed protected header claim "cic" in the ID Token
 		commitment = idt.GetSignature().GetProtectedClaims().CIC
 		if commitment == "" {
 			return fmt.Errorf("missing GQ commitment")

--- a/providers/providerverifier.go
+++ b/providers/providerverifier.go
@@ -236,7 +236,7 @@ func (v *DefaultProviderVerifier) verifyCommitment(idt *oidc.Jwt, cic *clientins
 				v.options.GQAudiencePrefix, audStr)
 		}
 
-		// Get the commitment from the GQ signed protected header claim "cic" in the ID Token
+		// "cic" is in the outer header, which the GQ signature binds.
 		commitment = idt.GetSignature().GetProtectedClaims().CIC
 		if commitment == "" {
 			return fmt.Errorf("missing GQ commitment")


### PR DESCRIPTION
## Summary
- Add a test proving the GQ signature does not cover the outer protected header
- Fix GQ sign/verify to bind the outer protected header into the signature

🤖 Generated with [Claude Code](https://claude.com/claude-code) - Reviewed and edited by @EthanHeilman 

This moves the GQ signature from signing the JWT payload and protected headers, to signing the JWT payload and GQ protected headers. The GQ signature still covers the JWT protected headers because the JWT protected headers are stored in the GQ protected header as the `QG_JWT.protected_headers.kid=base64(JWT.protected_headers)`

## Security Impact

This only has a security impact for GitLab GQ-commitment PK Tokens. GitHub only uses GQ signatures for replay protection and binds the users public key to the ID Token via the audience (`aud`) claim.

See [Docs/PK Tokens - GQ-Commitment PK Tokens (Gitlab-CI Example)](https://github.com/openpubkey/openpubkey/blob/d30b081b83f60f70793b124e46ffcd2620286b4d/docs/pktoken.md#gq-commitment-pk-tokens-gitlab-ci-example)

## Compatibility

This is a non-backwards compatible change:
  - Signatures produced by code prior to this change will not verify on code after this change.
  - Signatures produced by code after this change will not verify on code prior to this change.
