### PR TITLE
Fixes action perms for go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,9 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  contents: read
+
 jobs:
   golangci-linter:
     name: Run golangci linter


### PR DESCRIPTION
Addressing code scanning advisories 
- https://github.com/openpubkey/openpubkey/security/code-scanning/6
- https://github.com/openpubkey/openpubkey/security/code-scanning/4

By setting action permissions to read for this action