### PR TITLE
Fixes type conversation panics, adds regression tests

### DIFF
--- a/cosigner/authstate.go
+++ b/cosigner/authstate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openpubkey/openpubkey/oidc"
 	"github.com/openpubkey/openpubkey/pktoken"
 )
 
@@ -38,42 +39,16 @@ type AuthState struct {
 }
 
 func NewAuthState(pkt *pktoken.PKToken, ruri string, nonce string) (*AuthState, error) {
-	var claims struct {
-		Issuer string `json:"iss"`
-		Aud    any    `json:"aud"`
-		Sub    string `json:"sub"`
-		Email  string `json:"email"`
-	}
+	var claims oidc.OidcClaims
 	if err := json.Unmarshal(pkt.Payload, &claims); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal PK Token: %w", err)
-	}
-	// An audience can be a string or an array of strings.
-	//
-	// RFC-7519 JSON Web Token (JWT) says:
-	// "In the general case, the "aud" value is an array of case-
-	// sensitive strings, each containing a StringOrURI value.  In the
-	// special case when the JWT has one audience, the "aud" value MAY be a
-	// single case-sensitive string containing a StringOrURI value."
-	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
-	var audience string
-	switch t := claims.Aud.(type) {
-	case string:
-		audience = t
-	case []any:
-		audList := []string{}
-		for _, v := range t {
-			audList = append(audList, v.(string))
-		}
-		audience = strings.Join(audList, ",")
-	default:
-		return nil, fmt.Errorf("failed to deserialize aud (audience) claim in ID Token: %T", t)
 	}
 
 	return &AuthState{
 		Pkt:              pkt,
 		Issuer:           claims.Issuer,
-		Aud:              audience,
-		Sub:              claims.Sub,
+		Aud:              claims.Audience,
+		Sub:              claims.Subject,
 		Username:         claims.Email,
 		DisplayName:      strings.Split(claims.Email, "@")[0], //TODO: Use full name from ID Token
 		RedirectURI:      ruri,

--- a/cosigner/authstate_test.go
+++ b/cosigner/authstate_test.go
@@ -48,4 +48,13 @@ func TestAuthState(t *testing.T) {
 	require.Equal(t, "mockIssuer", userKey.Issuer, "issuer mismatch")
 	require.Equal(t, "empty", userKey.Aud, "aud mismatch")
 	require.Equal(t, "me", userKey.Sub, "issuer mismatch")
+
+	// Test corrupted auth state
+	corruptedPkt, err := mocks.GenerateMockPKToken(t, signer, alg)
+	require.NoError(t, err)
+
+	corruptedPkt.Payload = []byte(`{"iss":"https://example.com","aud":123}`) // Corrupt the audience claim
+
+	_, err = cosigner.NewAuthState(corruptedPkt, ruri, nonce)
+	require.Error(t, err, "failed to create auth state")
 }

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -56,17 +56,32 @@ func (id *OidcClaims) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// An audience can be a string or an array of strings.
+	//
+	// RFC-7519 JSON Web Token (JWT) says:
+	// "In the general case, the "aud" value is an array of case-
+	// sensitive strings, each containing a StringOrURI value.  In the
+	// special case when the JWT has one audience, the "aud" value MAY be a
+	// single case-sensitive string containing a StringOrURI value."
+	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
 	switch t := aux.Audience.(type) {
 	case string:
 		id.Audience = t
 	case []any:
 		audList := []string{}
 		for _, v := range t {
-			audList = append(audList, v.(string))
+			if audStr, ok := v.(string); ok {
+				audList = append(audList, audStr)
+			} else {
+				return fmt.Errorf("invalid audience type in audience list, got %T", v)
+			}
 		}
+		// TODO: Change audience to []string
 		id.Audience = strings.Join(audList, ",")
-	default:
+	case nil:
 		id.Audience = ""
+	default:
+		return fmt.Errorf("invalid audience type, got %T", t)
 	}
 
 	return nil

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oidc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openpubkey/openpubkey/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAudienceParsing(t *testing.T) {
+	testCases := []struct {
+		name          string
+		payload       string
+		errorExpected string
+		audExpected   string
+	}{
+		{
+			name:          "Happy case (aud is string)",
+			payload:       `{"iss":"https://example.com","aud":"abc"}`,
+			errorExpected: "",
+			audExpected:   "abc",
+		},
+		{
+			name:          "Happy case (aud is string list)",
+			payload:       `{"iss":"https://example.com","aud":["abc","def"]}`,
+			errorExpected: "",
+			audExpected:   "abc,def",
+		},
+		{
+			name:          "aud empty",
+			payload:       `{"iss":"https://example.com","aud":[]}`,
+			errorExpected: "",
+			audExpected:   "",
+		},
+		{
+			name:          "aud not specified",
+			payload:       `{"iss":"https://example.com"}`,
+			errorExpected: "",
+			audExpected:   "",
+		},
+		{
+			name:          "aud is a number not a string",
+			payload:       `{"iss":"https://example.com","aud":123}`,
+			errorExpected: "invalid audience type, got float64",
+			audExpected:   "",
+		},
+		{
+			name:          "aud list contains a boolean not a string",
+			payload:       `{"iss":"https://example.com","aud":["abc", true, "def"]}`,
+			errorExpected: "invalid audience type in audience list, got bool",
+			audExpected:   "",
+		},
+		{
+			name:          "aud list contains a null not a string",
+			payload:       `{"iss":"https://example.com","aud":[null]}`,
+			errorExpected: "invalid audience type in audience list, got <nil>",
+			audExpected:   "",
+		},
+		{
+			name:          "aud is not a key but an element",
+			payload:       `["aud"]`,
+			errorExpected: "json: cannot unmarshal array into Go value of type struct",
+			audExpected:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var claims OidcClaims
+			err := json.Unmarshal([]byte(tc.payload), &claims)
+			if tc.errorExpected != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorExpected)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.audExpected, claims.Audience)
+			}
+		})
+	}
+}
+
+func TestSplitCompact(t *testing.T) {
+	testCases := []struct {
+		name          string
+		value         string
+		expected      []string
+		errorExpected string
+	}{
+		{
+			name:          "Happy case",
+			value:         `aa.bb.cc`,
+			expected:      []string{"aa", "bb", "cc"},
+			errorExpected: "",
+		},
+		{
+			name:          "too few segments",
+			value:         `aa.bb`,
+			expected:      nil,
+			errorExpected: "invalid number of segments",
+		},
+		{
+			name:          "too many segments",
+			value:         `aa.bb.cc.dd`,
+			expected:      nil,
+			errorExpected: "invalid number of segments",
+		},
+		{
+			name:          "empty string",
+			value:         ``,
+			expected:      nil,
+			errorExpected: "invalid number of segments",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v1, v2, v3, err := SplitCompact([]byte(tc.value))
+			if tc.errorExpected != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorExpected)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, []string{string(v1), string(v2), string(v3)})
+			}
+		})
+	}
+}
+
+func TestParseJWTSegment(t *testing.T) {
+	testCases := []struct {
+		name           string
+		jwtSegment     []byte
+		claimsExpected OidcClaims
+		errorExpected  string
+	}{
+		{
+			name:           "Happy case",
+			jwtSegment:     util.Base64EncodeForJWT([]byte(`{"iss":"https://example.com","aud":["xyz"]}`)),
+			claimsExpected: OidcClaims{Issuer: "https://example.com", Audience: "xyz"},
+			errorExpected:  "",
+		},
+		{
+			name:           "bad base64 encoding",
+			jwtSegment:     []byte("invalid-base64"),
+			claimsExpected: OidcClaims{},
+			errorExpected:  "error decoding segment: illegal base64 data at input byte 12",
+		},
+		{
+			name:           "json unmarshal error",
+			jwtSegment:     util.Base64EncodeForJWT([]byte(`["string", "string2"]`)),
+			claimsExpected: OidcClaims{},
+			errorExpected:  "error parsing segment: json: cannot unmarshal array into Go value of type struct",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var claimsResult OidcClaims
+			err := ParseJWTSegment(tc.jwtSegment, &claimsResult)
+			if tc.errorExpected != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorExpected)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.claimsExpected, claimsResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To parse the `aud` claim in an ID Token, when the `aud` was a list we were were doing an unchecked `.(string)` conversation on each element. If one those audience elements was not a string the parsing code would throw a panic.

This PR:
* Fixes this issue in each place was found
* Deduplications parsing code
* Adds regression and additional test