### PR TITLE
fix: bridge OpenPubkeyBrowserURL into PowerShell via WSLENV on WSL

### DIFF
--- a/util/launch.go
+++ b/util/launch.go
@@ -100,7 +100,12 @@ func openWithPowerShell(url string, wsl bool) error {
 	// and Start-Process opens nothing. Scoped to this child only.
 	// https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/
 	if wsl {
-		cmd.Env = append(cmd.Env, "WSLENV="+envVar+"/w")
+		// Preserve any existing WSLENV.
+		wslenv := os.Getenv("WSLENV")
+		if wslenv != "" {
+			wslenv += ":"
+		}
+		cmd.Env = append(cmd.Env, "WSLENV="+wslenv+envVar+"/w")
 	}
 	return cmd.Start()
 }

--- a/util/launch.go
+++ b/util/launch.go
@@ -33,14 +33,14 @@ import (
 func OpenUrl(url string) error {
 	switch runtime.GOOS {
 	case "windows":
-		return openWithPowerShell(url)
+		return openWithPowerShell(url, false)
 
 	case "darwin":
 		return exec.Command("open", url).Start()
 
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		if isWSL() {
-			return openWithPowerShell(url)
+			return openWithPowerShell(url, true)
 		}
 		return exec.Command("xdg-open", url).Start()
 	}
@@ -73,7 +73,7 @@ func validateHTTPURL(rawURL string) error {
 // of -Command because -Command re-joins and re-parses all trailing argv
 // entries as a single script, which would otherwise require additional care
 // to avoid argv-splitting ambiguity.
-func openWithPowerShell(url string) error {
+func openWithPowerShell(url string, wsl bool) error {
 	if err := validateHTTPURL(url); err != nil {
 		return err
 	}
@@ -95,6 +95,13 @@ func openWithPowerShell(url string) error {
 
 	cmd := exec.Command("powershell.exe", "-NoProfile", "-EncodedCommand", encoded)
 	cmd.Env = append(os.Environ(), envVar+"="+url)
+	// On WSL, Win32 processes only inherit Linux env vars listed in WSLENV.
+	// Without that bridge, $Env:OpenPubkeyBrowserURL is empty in PowerShell
+	// and Start-Process opens nothing. Scoped to this child only.
+	// https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/
+	if wsl {
+		cmd.Env = append(cmd.Env, "WSLENV="+envVar+"/w")
+	}
 	return cmd.Start()
 }
 


### PR DESCRIPTION
The injection-hardening in #374 passes the URL through an environment variable (OpenPubkeyBrowserURL) instead of the script text. That works on native Windows, but on WSL powershell.exe runs as a Win32 process and Linux env vars only cross the boundary if listed in WSLENV. Without that bridge $Env:OpenPubkeyBrowserURL is empty and Start-Process opens nothing. Set WSLENV on the child process (with the /w flag) when running under WSL so the variable is shared into PowerShell.

https://github.com/user-attachments/assets/a277df3a-f335-4c34-8f92-ca21e2cf5460

Ref: https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/

**Workaround** (applicable only to WSL)
Until this fix is available, prefix the command with the `WSLENV` bridge:   
```sh
WSLENV='OpenPubkeyBrowserURL/w' go run ./examples/simple
```