### PR TITLE
feat: add timeouts to browser authentication flows

### DIFF
--- a/client/choosers/web_chooser.go
+++ b/client/choosers/web_chooser.go
@@ -28,7 +28,9 @@ import (
 	"net/http/httptest"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/openpubkey/openpubkey/internal/httpserver"
 	"github.com/openpubkey/openpubkey/providers"
 	"github.com/openpubkey/openpubkey/util"
 )
@@ -50,13 +52,17 @@ var chooserTemplateFile string
 
 type WebChooser struct {
 	util.OutOrErrWriter
-	OpList        []providers.BrowserOpenIdProvider
-	opSelected    providers.BrowserOpenIdProvider
-	OpenBrowser   bool
-	useMockServer bool
-	mockServer    *httptest.Server
-	server        *http.Server
-	loginURIHook  LoginURIHook
+	OpList      []providers.BrowserOpenIdProvider
+	opSelected  providers.BrowserOpenIdProvider
+	OpenBrowser bool
+	// AuthWaitTimeout bounds how long ChooseOp waits for the user to pick a
+	// provider in the browser. Zero means providers.DefaultAuthWaitTimeout
+	// (10 minutes). A negative value disables the library timeout so only the
+	// parent context can cancel the wait.
+	AuthWaitTimeout time.Duration
+	useMockServer   bool
+	server          *http.Server
+	loginURIHook    LoginURIHook
 	// browserOpener replaces util.OpenUrl in tests that exercise browser-open
 	// success and failure paths.
 	browserOpener func(string) error
@@ -117,6 +123,10 @@ func (wc *WebChooser) ChooseOp(ctx context.Context) (providers.OpenIdProvider, e
 	if err != nil {
 		return nil, err
 	}
+	authCtx, cancelAuth := providers.WithAuthWaitTimeout(ctx, wc.AuthWaitTimeout)
+	chooseDone := make(chan struct{})
+	defer close(chooseDone)
+	shutdownCh := make(chan struct{}, 1)
 
 	mux.HandleFunc("/chooser", func(w http.ResponseWriter, r *http.Request) {
 		type Provider struct {
@@ -178,20 +188,12 @@ func (wc *WebChooser) ChooseOp(ctx context.Context) (providers.OpenIdProvider, e
 	})
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticContent))))
 	mux.HandleFunc("/select/", func(w http.ResponseWriter, r *http.Request) {
-		// Once we redirect to the OP localhost webserver, we can shutdown the web chooser localhost server
-		shutdownServer := func() {
-			go func() { // Put this in a go func so that it will not block the redirect
-				if wc.server != nil {
-					if err := wc.server.Shutdown(ctx); err != nil {
-						select {
-						case errCh <- fmt.Errorf("failed to shutdown HTTP server: %w", err):
-						default:
-						}
-					}
-				}
-			}()
-		}
-		defer shutdownServer()
+		defer func() {
+			select {
+			case shutdownCh <- struct{}{}:
+			default:
+			}
+		}()
 
 		opName := r.URL.Query().Get("op")
 		if opName == "" {
@@ -207,31 +209,58 @@ func (wc *WebChooser) ChooseOp(ctx context.Context) (providers.OpenIdProvider, e
 			return
 		} else {
 			wc.setProviderDefaultWriters(op)
-			opCh <- op
-
 			redirectUriCh := make(chan string, 1)
 			op.ReuseBrowserWindowHook(redirectUriCh)
+			// Publish the provider only after its browser-window hook is fully
+			// configured. The caller may begin RequestTokens as soon as it
+			// receives op, and that method reads the hook.
+			select {
+			case opCh <- op:
+			case <-r.Context().Done():
+				return
+			}
 
-			redirectUri := <-redirectUriCh
-			http.Redirect(w, r, redirectUri, http.StatusFound)
+			select {
+			case redirectURI := <-redirectUriCh:
+				http.Redirect(w, r, redirectURI, http.StatusFound)
+			case <-r.Context().Done():
+				return
+			}
 		}
 	})
 
+	var callbackServer *http.Server
+	var testServer *httptest.Server
 	if wc.useMockServer {
-		wc.mockServer = httptest.NewUnstartedServer(mux)
-		wc.mockServer.Start()
+		testServer = httptest.NewUnstartedServer(mux)
+		testServer.Config.BaseContext = func(net.Listener) context.Context { return authCtx }
+		testServer.Start()
+		callbackServer = testServer.Config
+		if wc.loginURIHook != nil {
+			if err := wc.loginURIHook(testServer.URL + "/chooser"); err != nil {
+				cancelAuth()
+				_ = callbackServer.Close()
+				testServer.Close()
+				return nil, fmt.Errorf("login URI hook failed: %w", err)
+			}
+		}
 	} else {
 		listener, err := net.Listen("tcp", "localhost:0")
 		if err != nil {
+			cancelAuth()
 			return nil, fmt.Errorf("failed to bind to an available port: %w", err)
 		}
-		wc.server = &http.Server{Handler: mux}
+		wc.server = &http.Server{
+			Handler:     mux,
+			BaseContext: func(net.Listener) context.Context { return authCtx },
+		}
+		callbackServer = wc.server
 		go func() {
-			serveErr := wc.server.Serve(listener)
+			serveErr := callbackServer.Serve(listener)
 			if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 				select {
 				case errCh <- fmt.Errorf("web chooser server failed: %w", serveErr):
-				case <-ctx.Done():
+				case <-authCtx.Done():
 				}
 			}
 		}()
@@ -247,9 +276,8 @@ func (wc *WebChooser) ChooseOp(ctx context.Context) (providers.OpenIdProvider, e
 
 		if wc.loginURIHook != nil {
 			if err := wc.loginURIHook(loginURI); err != nil {
-				if shutdownErr := wc.server.Shutdown(ctx); shutdownErr != nil {
-					_, _ = fmt.Fprintf(wc.ErrWriter(), "Failed to shutdown HTTP server: %v\n", shutdownErr)
-				}
+				cancelAuth()
+				_ = callbackServer.Close()
 				return nil, fmt.Errorf("login URI hook failed: %w", err)
 			}
 		}
@@ -258,10 +286,40 @@ func (wc *WebChooser) ChooseOp(ctx context.Context) (providers.OpenIdProvider, e
 
 	}
 
+	// The server outlives ChooseOp after a successful selection so it can
+	// redirect the same browser window to the selected provider. Its lifecycle
+	// goroutine retains the auth deadline and owns final cleanup.
+	go func(server *http.Server, testServer *httptest.Server) {
+		defer func() {
+			// Do not cancel authCtx until ChooseOp has consumed the provider or
+			// handler error; otherwise cleanup could mask that result as a
+			// context cancellation.
+			<-chooseDone
+			cancelAuth()
+		}()
+		select {
+		case <-shutdownCh:
+			if err := httpserver.Shutdown(server, time.Second); err != nil {
+				select {
+				case errCh <- fmt.Errorf("failed to shutdown HTTP server: %w", err):
+				default:
+				}
+			}
+		case <-authCtx.Done():
+			_ = server.Close()
+		}
+		if testServer != nil {
+			testServer.Close()
+		}
+	}(callbackServer, testServer)
+
 	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	case <-authCtx.Done():
+		_ = callbackServer.Close()
+		return nil, providers.AuthWaitError(authCtx, wc.AuthWaitTimeout)
 	case err := <-errCh:
+		cancelAuth()
+		_ = callbackServer.Close()
 		return nil, err
 	case wc.opSelected = <-opCh:
 		return wc.opSelected, nil

--- a/client/choosers/web_chooser_test.go
+++ b/client/choosers/web_chooser_test.go
@@ -21,8 +21,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -33,15 +35,19 @@ import (
 
 const manualBrowserMessage = "Open your browser to:"
 
-func CreateServerToHandleRedirect(t *testing.T, gotRedirect *bool) (*httptest.Server, string) {
+func CreateServerToHandleRedirect(t *testing.T) (*httptest.Server, string, <-chan struct{}) {
+	redirected := make(chan struct{}, 1)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
-		*gotRedirect = true
+		select {
+		case redirected <- struct{}{}:
+		default:
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	mockServer := httptest.NewUnstartedServer(mux)
 	mockServer.Start()
-	return mockServer, mockServer.URL + "/redirect"
+	return mockServer, mockServer.URL + "/redirect", redirected
 }
 
 func TestGoogleSelection(t *testing.T) {
@@ -82,12 +88,16 @@ func TestGoogleSelection(t *testing.T) {
 				OpenBrowser:   false,
 				useMockServer: true,
 			}
+			chooserURICh := make(chan string, 1)
+			webChooser.SetLoginURIHook(func(uri string) error {
+				chooserURICh <- uri
+				return nil
+			})
 
 			var chooserErr error
 			var op providers.OpenIdProvider
 
-			gotRedirect := false
-			redirectServer, redirectUri := CreateServerToHandleRedirect(t, &gotRedirect)
+			redirectServer, redirectUri, redirected := CreateServerToHandleRedirect(t)
 
 			testRunDone := make(chan struct{})
 			go func() {
@@ -121,27 +131,24 @@ func TestGoogleSelection(t *testing.T) {
 					azureOp.(*providers.StandardOp).TriggerBrowserWindowHook(redirectUri)
 				}
 
-				require.Eventually(t,
-					func() bool { return gotRedirect },
-					100*time.Millisecond, 1*time.Millisecond, "redirect not triggered but should have been",
-				)
+				select {
+				case <-redirected:
+				case <-time.After(time.Second):
+					t.Error("redirect not triggered but should have been")
+				}
 			}()
 
-			// Wait until the server is listening
-			require.Eventually(t, func() bool {
-				return chooserErr != nil || webChooser.mockServer != nil && webChooser.mockServer.URL != ""
-			}, 3*time.Second, 100*time.Millisecond)
-
-			if chooserErr != nil {
-				if tc.errorString != "" {
-					require.ErrorContains(t, chooserErr, tc.errorString)
-				} else {
-					require.NoError(t, chooserErr)
-				}
+			var chooserURI string
+			select {
+			case chooserURI = <-chooserURICh:
+			case <-time.After(3 * time.Second):
+				t.Fatal("web chooser server did not start")
 			}
 
 			// Make a request to the server to trigger Google selection and get redirect
-			resp, err := http.Get(webChooser.mockServer.URL + "/select?op=" + tc.providerName)
+			parsedChooserURI, err := url.Parse(chooserURI)
+			require.NoError(t, err)
+			resp, err := http.Get(parsedChooserURI.Scheme + "://" + parsedChooserURI.Host + "/select?op=" + tc.providerName)
 			if tc.httpCodeExpected != http.StatusOK {
 				require.Equal(t, tc.httpCodeExpected, resp.StatusCode)
 			} else {
@@ -159,6 +166,9 @@ func TestGoogleSelection(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatal("test timed out")
 			}
+			require.Eventually(t, func() bool {
+				return listenerClosed(chooserURI)
+			}, time.Second, 10*time.Millisecond, "web chooser listener remained open")
 		})
 	}
 
@@ -366,4 +376,38 @@ func TestIssuerToName(t *testing.T) {
 	name, err = IssuerToName("error.example.com")
 	require.ErrorContains(t, err, "invalid OpenID Provider issuer: error.example.com")
 	require.Equal(t, "", name)
+}
+
+func TestChooseOpAuthWaitTimeout(t *testing.T) {
+	googleOp := providers.NewGoogleOpWithOptions(providers.GetDefaultGoogleOpOptions())
+	webChooser := NewWebChooser([]providers.BrowserOpenIdProvider{googleOp}, false)
+	webChooser.AuthWaitTimeout = 50 * time.Millisecond
+	var chooserURI string
+	webChooser.SetLoginURIHook(func(uri string) error {
+		chooserURI = uri
+		return nil
+	})
+
+	op, err := webChooser.ChooseOp(context.Background())
+	require.Nil(t, op)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "authentication timed out after waiting 50ms")
+	requireListenerClosed(t, chooserURI)
+}
+
+func requireListenerClosed(t *testing.T, rawURL string) {
+	t.Helper()
+	require.True(t, listenerClosed(rawURL), "callback listener is still accepting connections")
+}
+
+func listenerClosed(rawURL string) bool {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	connection, err := net.DialTimeout("tcp", parsedURL.Host, 100*time.Millisecond)
+	if connection != nil {
+		_ = connection.Close()
+	}
+	return err != nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -165,10 +165,16 @@ func (o *OpkClient) Auth(ctx context.Context, opts ...AuthOpts) (*pktoken.PKToke
 		return nil, fmt.Errorf("OP supplied does not have support for MFA Cosigner")
 	} else {
 		redirCh := make(chan string, 1)
+		handoffDone := make(chan struct{})
+		defer close(handoffDone)
 
 		browserOp.HookHTTPSession(func(w http.ResponseWriter, r *http.Request) {
-			redirectUri := <-redirCh
-			http.Redirect(w, r, redirectUri, http.StatusFound)
+			select {
+			case redirectURI := <-redirCh:
+				http.Redirect(w, r, redirectURI, http.StatusFound)
+			case <-handoffDone:
+			case <-r.Context().Done():
+			}
 		})
 
 		pkt, err := o.oidcAuth(ctx, o.signer, o.alg, authOpts.extraClaims)

--- a/client/cos.go
+++ b/client/cos.go
@@ -33,13 +33,20 @@ import (
 
 	"github.com/lestrrat-go/jwx/v3/jws"
 	"github.com/openpubkey/openpubkey/cosigner/msgs"
+	"github.com/openpubkey/openpubkey/internal/httpserver"
 	"github.com/openpubkey/openpubkey/pktoken"
+	"github.com/openpubkey/openpubkey/providers"
 	"github.com/openpubkey/openpubkey/util"
 )
 
 type CosignerProvider struct {
 	Issuer       string
 	CallbackPath string
+	// AuthWaitTimeout bounds how long RequestToken waits for the cosigner
+	// browser callback. Zero means providers.DefaultAuthWaitTimeout
+	// (10 minutes). A negative value disables the library timeout so only the
+	// parent context can cancel the wait.
+	AuthWaitTimeout time.Duration
 }
 
 func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signer, pkt *pktoken.PKToken, redirCh chan string) (*pktoken.PKToken, error) {
@@ -83,10 +90,15 @@ func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signe
 				if err != nil {
 					return nil, fmt.Errorf("cosigner client hit error when building authcode URI: %w", err)
 				}
-				res, err := http.Get(authcodeSigUri)
+				request, err := http.NewRequestWithContext(r.Context(), http.MethodGet, authcodeSigUri, nil)
+				if err != nil {
+					return nil, fmt.Errorf("error creating MFA cosigner signature request: %w", err)
+				}
+				res, err := http.DefaultClient.Do(request)
 				if err != nil {
 					return nil, fmt.Errorf("error requesting MFA cosigner signature: %w", err)
 				}
+				defer res.Body.Close()
 
 				// Receive response from Cosigner that has cosigner signature on PK Token
 				resBody, err := io.ReadAll(res.Body)
@@ -107,7 +119,7 @@ func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signe
 
 				select {
 				case errCh <- err:
-				case <-ctx.Done():
+				case <-r.Context().Done():
 					return
 				}
 			} else {
@@ -115,7 +127,7 @@ func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signe
 
 				select {
 				case sigCh <- cosSig:
-				case <-ctx.Done():
+				case <-r.Context().Done():
 					return
 				}
 			}
@@ -126,7 +138,11 @@ func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signe
 	server := &http.Server{
 		Addr:    host,
 		Handler: mux,
+		BaseContext: func(net.Listener) context.Context {
+			return ctx
+		},
 	}
+	forceClose := false
 	go func() {
 		err := server.Serve(listener)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -137,7 +153,11 @@ func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signe
 		}
 	}()
 	defer func() {
-		_ = server.Shutdown(ctx)
+		if forceClose {
+			_ = server.Close()
+			return
+		}
+		_ = httpserver.Shutdown(server, time.Second)
 	}()
 
 	pktJson, err := json.Marshal(pkt)
@@ -159,11 +179,15 @@ func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signe
 		return nil, fmt.Errorf("cosigner client hit error when building init auth URI: %w", err)
 	}
 
+	authCtx, cancelAuth := providers.WithAuthWaitTimeout(ctx, c.AuthWaitTimeout)
+	defer cancelAuth()
+
 	select {
 	// Trigger redirect of user's browser window to a URI controlled by the Cosigner sending the PK Token in the URI
 	case redirCh <- redirUri:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	case <-authCtx.Done():
+		forceClose = true
+		return nil, providers.AuthWaitError(authCtx, c.AuthWaitTimeout)
 	}
 
 	select {
@@ -178,8 +202,9 @@ func (c *CosignerProvider) RequestToken(ctx context.Context, signer crypto.Signe
 		return pkt, nil
 	case err := <-errCh:
 		return nil, err
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	case <-authCtx.Done():
+		forceClose = true
+		return nil, providers.AuthWaitError(authCtx, c.AuthWaitTimeout)
 	}
 }
 

--- a/client/cos_test.go
+++ b/client/cos_test.go
@@ -17,9 +17,21 @@
 package client
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/openpubkey/openpubkey/cosigner/msgs"
+	"github.com/openpubkey/openpubkey/jose"
+	pktokenmocks "github.com/openpubkey/openpubkey/pktoken/mocks"
+	"github.com/openpubkey/openpubkey/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +59,103 @@ func TestCosSimple(t *testing.T) {
 	require.NotNil(t, authCodeUri)
 	require.Equal(t, "https://example.com/sign?sig2=fake+signature+two+bytes", authCodeUri)
 	require.NoError(t, err)
+}
+
+func TestCosignerAuthWaitTimeoutClosesServerAndCancelsHandler(t *testing.T) {
+	signRequestStarted := make(chan struct{})
+	signRequestCanceled := make(chan struct{})
+	cosignerServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(signRequestStarted)
+		<-r.Context().Done()
+		close(signRequestCanceled)
+	}))
+	defer cosignerServer.Close()
+
+	signer, err := util.GenKeyPair(jose.ES256)
+	require.NoError(t, err)
+	pkt, err := pktokenmocks.GenerateMockPKToken(t, signer, jose.ES256)
+	require.NoError(t, err)
+
+	cosignerProvider := CosignerProvider{
+		Issuer:          cosignerServer.URL,
+		CallbackPath:    "/mfaredirect",
+		AuthWaitTimeout: 500 * time.Millisecond,
+	}
+	redirectCh := make(chan string, 1)
+	resultCh := make(chan error, 1)
+	go func() {
+		_, requestErr := cosignerProvider.RequestToken(context.Background(), signer, pkt, redirectCh)
+		resultCh <- requestErr
+	}()
+
+	callbackURI := callbackURIFromCosignerRedirect(t, <-redirectCh)
+	callbackDone := make(chan error, 1)
+	go func() {
+		response, callbackErr := http.Get(callbackURI + "?authcode=test-authcode")
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		callbackDone <- callbackErr
+	}()
+
+	select {
+	case <-signRequestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("cosigner signature request did not start")
+	}
+
+	select {
+	case err := <-resultCh:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Contains(t, err.Error(), "authentication timed out after waiting 500ms")
+	case <-time.After(2 * time.Second):
+		t.Fatal("RequestToken did not return after its authentication timeout")
+	}
+
+	select {
+	case <-signRequestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("closing the callback server did not cancel its active handler")
+	}
+	require.Error(t, <-callbackDone)
+
+	parsedCallbackURI, err := url.Parse(callbackURI)
+	require.NoError(t, err)
+	connection, err := net.DialTimeout("tcp", parsedCallbackURI.Host, 100*time.Millisecond)
+	if connection != nil {
+		_ = connection.Close()
+	}
+	require.Error(t, err, "cosigner callback listener is still accepting connections")
+}
+
+func TestCosignerAuthWaitTimeoutIncludesRedirectHandoff(t *testing.T) {
+	signer, err := util.GenKeyPair(jose.ES256)
+	require.NoError(t, err)
+	pkt, err := pktokenmocks.GenerateMockPKToken(t, signer, jose.ES256)
+	require.NoError(t, err)
+
+	cosignerProvider := CosignerProvider{
+		Issuer:          "https://example.com",
+		CallbackPath:    "/mfaredirect",
+		AuthWaitTimeout: 30 * time.Millisecond,
+	}
+	started := time.Now()
+	result, err := cosignerProvider.RequestToken(
+		context.Background(), signer, pkt, make(chan string),
+	)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "authentication timed out after waiting 30ms")
+	require.Less(t, time.Since(started), time.Second)
+}
+
+func callbackURIFromCosignerRedirect(t *testing.T, redirect string) string {
+	t.Helper()
+	redirectURI, err := url.Parse(redirect)
+	require.NoError(t, err)
+	message, err := jws.Parse([]byte(redirectURI.Query().Get("sig1")))
+	require.NoError(t, err)
+	var initAuth msgs.InitMFAAuth
+	require.NoError(t, json.Unmarshal(message.Payload(), &initAuth))
+	return initAuth.RedirectUri
 }

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -1,0 +1,55 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpserver contains lifecycle helpers for HTTP servers owned by the
+// library.
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// Shutdown gives active handlers up to gracePeriod to finish, then forcibly
+// closes the server. It always uses an independent context because the request
+// context that triggered cleanup is commonly already canceled.
+func Shutdown(server *http.Server, gracePeriod time.Duration) error {
+	if server == nil {
+		return nil
+	}
+	if gracePeriod <= 0 {
+		return closeServer(server)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), gracePeriod)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		if closeErr := closeServer(server); closeErr != nil {
+			return errors.Join(err, closeErr)
+		}
+	}
+	return nil
+}
+
+func closeServer(server *http.Server) error {
+	err := server.Close()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpserver
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdownForcesActiveHandlerClosedAfterGracePeriod(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	handlerStarted := make(chan struct{})
+	handlerCanceled := make(chan struct{})
+	server := &http.Server{Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(handlerStarted)
+		<-r.Context().Done()
+		close(handlerCanceled)
+	})}
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- server.Serve(listener)
+	}()
+
+	requestDone := make(chan error, 1)
+	go func() {
+		response, requestErr := http.Get("http://" + listener.Addr().String())
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		requestDone <- requestErr
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not start")
+	}
+
+	started := time.Now()
+	require.NoError(t, Shutdown(server, 20*time.Millisecond))
+	require.Less(t, time.Since(started), time.Second)
+
+	select {
+	case <-handlerCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("forced close did not cancel the active handler")
+	}
+	require.Error(t, <-requestDone)
+	require.ErrorIs(t, <-serveDone, http.ErrServerClosed)
+
+	dialer := net.Dialer{Timeout: 100 * time.Millisecond}
+	connection, err := dialer.DialContext(context.Background(), "tcp", listener.Addr().String())
+	if connection != nil {
+		_ = connection.Close()
+	}
+	require.Error(t, err)
+}
+
+func TestShutdownTreatsAlreadyClosedServerAsSuccess(t *testing.T) {
+	server := &http.Server{}
+	require.NoError(t, server.Close())
+	require.NoError(t, Shutdown(server, time.Second))
+}

--- a/providers/auth_wait.go
+++ b/providers/auth_wait.go
@@ -1,0 +1,72 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// DefaultAuthWaitTimeout is how long browser-based localhost auth flows wait
+// for the user to finish before the library cancels the wait. Matches the
+// ~10 minute bound used by public PKCE loopback CLIs such as AWS SSO login.
+const DefaultAuthWaitTimeout = 10 * time.Minute
+
+var errAuthWaitTimeout = errors.New("authentication wait timeout")
+
+// ResolveAuthWaitTimeout returns the effective auth-wait duration.
+// A zero value means DefaultAuthWaitTimeout. A negative value disables the
+// library timeout (only the parent context can cancel the wait).
+func ResolveAuthWaitTimeout(timeout time.Duration) time.Duration {
+	if timeout < 0 {
+		return timeout
+	}
+	if timeout == 0 {
+		return DefaultAuthWaitTimeout
+	}
+	return timeout
+}
+
+// WithAuthWaitTimeout returns a child context that expires when the auth-wait
+// timeout elapses, unless timeout is negative (no library timeout) or the
+// parent context already has an earlier deadline.
+//
+// Callers should always defer the returned cancel function.
+func WithAuthWaitTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	timeout = ResolveAuthWaitTimeout(timeout)
+	if timeout < 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeoutCause(ctx, timeout, errAuthWaitTimeout)
+}
+
+// AuthWaitError wraps a context deadline/cancel error from an auth wait with a
+// clearer message when the library's auth timeout elapsed. Parent context
+// cancellation and deadlines are returned unchanged.
+func AuthWaitError(ctx context.Context, timeout time.Duration) error {
+	err := ctx.Err()
+	if err == nil {
+		return nil
+	}
+	timeout = ResolveAuthWaitTimeout(timeout)
+	if errors.Is(context.Cause(ctx), errAuthWaitTimeout) && timeout > 0 {
+		return fmt.Errorf("authentication timed out after waiting %s: %w", timeout, err)
+	}
+	return err
+}

--- a/providers/auth_wait_test.go
+++ b/providers/auth_wait_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAuthWaitTimeout(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, DefaultAuthWaitTimeout, ResolveAuthWaitTimeout(0))
+	require.Equal(t, 2*time.Minute, ResolveAuthWaitTimeout(2*time.Minute))
+	require.Equal(t, time.Duration(-1), ResolveAuthWaitTimeout(-1))
+}
+
+func TestWithAuthWaitTimeoutHonorsParentDeadline(t *testing.T) {
+	t.Parallel()
+	parent, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	authCtx, cancelAuth := WithAuthWaitTimeout(parent, time.Hour)
+	defer cancelAuth()
+
+	deadline, ok := authCtx.Deadline()
+	require.True(t, ok)
+	parentDeadline, ok := parent.Deadline()
+	require.True(t, ok)
+	require.Equal(t, parentDeadline, deadline)
+
+	<-authCtx.Done()
+	require.ErrorIs(t, authCtx.Err(), context.DeadlineExceeded)
+	err := AuthWaitError(authCtx, time.Hour)
+	require.Equal(t, context.DeadlineExceeded, err)
+	require.NotContains(t, err.Error(), "authentication timed out")
+}
+
+func TestWithAuthWaitTimeoutHonorsAlreadyCanceledParent(t *testing.T) {
+	t.Parallel()
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	authCtx, cancelAuth := WithAuthWaitTimeout(parent, time.Hour)
+	defer cancelAuth()
+	<-authCtx.Done()
+	require.Equal(t, context.Canceled, AuthWaitError(authCtx, time.Hour))
+}
+
+func TestWithAuthWaitTimeoutAppliesDefault(t *testing.T) {
+	t.Parallel()
+	authCtx, cancelAuth := WithAuthWaitTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelAuth()
+
+	<-authCtx.Done()
+	err := AuthWaitError(authCtx, 20*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "authentication timed out after waiting 20ms")
+}
+
+func TestWithAuthWaitTimeoutNegativeDisables(t *testing.T) {
+	t.Parallel()
+	parent, cancelParent := context.WithCancel(context.Background())
+	authCtx, cancelAuth := WithAuthWaitTimeout(parent, -1)
+	defer cancelAuth()
+
+	_, ok := authCtx.Deadline()
+	require.False(t, ok)
+	select {
+	case <-authCtx.Done():
+		t.Fatal("negative timeout expired without parent cancellation")
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancelParent()
+	<-authCtx.Done()
+	require.Equal(t, context.Canceled, AuthWaitError(authCtx, -1))
+}
+
+func TestAuthWaitErrorPassthrough(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, AuthWaitError(context.Background(), time.Minute))
+
+	canceledCtx, cancel := context.WithCancelCause(context.Background())
+	err := errors.New("other")
+	cancel(err)
+	require.ErrorIs(t, context.Cause(canceledCtx), err)
+	require.ErrorIs(t, AuthWaitError(canceledCtx, time.Minute), context.Canceled)
+}

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -81,6 +81,11 @@ type AzureOptions struct {
 	// CallbackHTML is the HTML content to display to the user after successful
 	// authentication. If empty, defaults to "You may now close this window".
 	CallbackHTML string
+	// AuthWaitTimeout bounds how long the authorization-code localhost callback
+	// wait blocks for the user to finish browser login. Zero means
+	// DefaultAuthWaitTimeout (10 minutes). A negative value disables the
+	// library timeout so only the parent context can cancel the wait.
+	AuthWaitTimeout time.Duration
 }
 
 func GetDefaultAzureOpOptions() *AzureOptions {
@@ -97,11 +102,12 @@ func GetDefaultAzureOpOptions() *AzureOptions {
 			"http://localhost:10001/login-callback",
 			"http://localhost:11110/login-callback",
 		},
-		GQSign:         false,
-		OpenBrowser:    true,
-		HttpClient:     nil,
-		IssuedAtOffset: 1 * time.Minute,
-		CallbackHTML:   defaultCallbackHTML,
+		GQSign:          false,
+		OpenBrowser:     true,
+		HttpClient:      nil,
+		IssuedAtOffset:  1 * time.Minute,
+		CallbackHTML:    defaultCallbackHTML,
+		AuthWaitTimeout: DefaultAuthWaitTimeout,
 	}
 }
 
@@ -130,6 +136,7 @@ func NewAzureOpWithOptions(opts *AzureOptions) BrowserOpenIdProvider {
 			HttpClient:                opts.HttpClient,
 			IssuedAtOffset:            opts.IssuedAtOffset,
 			CallbackHTML:              callbackHTMLOrDefault(opts.CallbackHTML),
+			AuthWaitTimeout:           opts.AuthWaitTimeout,
 			issuer:                    opts.Issuer,
 			RemoteRedirectURI:         opts.RemoteRedirectURI,
 			requestTokensOverrideFunc: nil,

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -73,6 +73,11 @@ type GitlabOptions struct {
 	// CallbackHTML is the HTML content to display to the user after successful
 	// authentication. If empty, defaults to "You may now close this window".
 	CallbackHTML string
+	// AuthWaitTimeout bounds how long the authorization-code localhost callback
+	// wait blocks for the user to finish browser login. Zero means
+	// DefaultAuthWaitTimeout (10 minutes). A negative value disables the
+	// library timeout so only the parent context can cancel the wait.
+	AuthWaitTimeout time.Duration
 }
 
 // NewGitlabOp creates a Gitlab OP (OpenID Provider) using the
@@ -96,11 +101,12 @@ func GetDefaultGitlabOpOptions() *GitlabOptions {
 			"http://localhost:10001/login-callback",
 			"http://localhost:11110/login-callback",
 		},
-		GQSign:         false,
-		OpenBrowser:    true,
-		HttpClient:     nil,
-		IssuedAtOffset: 1 * time.Minute,
-		CallbackHTML:   defaultCallbackHTML,
+		GQSign:          false,
+		OpenBrowser:     true,
+		HttpClient:      nil,
+		IssuedAtOffset:  1 * time.Minute,
+		CallbackHTML:    defaultCallbackHTML,
+		AuthWaitTimeout: DefaultAuthWaitTimeout,
 	}
 }
 
@@ -119,6 +125,7 @@ func NewGitlabOpWithOptions(opts *GitlabOptions) BrowserOpenIdProvider {
 			HttpClient:                opts.HttpClient,
 			IssuedAtOffset:            opts.IssuedAtOffset,
 			CallbackHTML:              callbackHTMLOrDefault(opts.CallbackHTML),
+			AuthWaitTimeout:           opts.AuthWaitTimeout,
 			issuer:                    opts.Issuer,
 			requestTokensOverrideFunc: nil,
 			publicKeyFinder: discover.PublicKeyFinder{

--- a/providers/google.go
+++ b/providers/google.go
@@ -79,6 +79,11 @@ type GoogleOptions struct {
 	// CallbackHTML is the HTML content to display to the user after successful
 	// authentication. If empty, defaults to "You may now close this window".
 	CallbackHTML string
+	// AuthWaitTimeout bounds how long the authorization-code localhost callback
+	// wait blocks for the user to finish browser login. Zero means
+	// DefaultAuthWaitTimeout (10 minutes). A negative value disables the
+	// library timeout so only the parent context can cancel the wait.
+	AuthWaitTimeout time.Duration
 }
 
 func GetDefaultGoogleOpOptions() *GoogleOptions {
@@ -96,11 +101,12 @@ func GetDefaultGoogleOpOptions() *GoogleOptions {
 			"http://localhost:10001/login-callback",
 			"http://localhost:11110/login-callback",
 		},
-		GQSign:         false,
-		OpenBrowser:    true,
-		HttpClient:     nil,
-		IssuedAtOffset: 1 * time.Minute,
-		CallbackHTML:   defaultCallbackHTML,
+		GQSign:          false,
+		OpenBrowser:     true,
+		HttpClient:      nil,
+		IssuedAtOffset:  1 * time.Minute,
+		CallbackHTML:    defaultCallbackHTML,
+		AuthWaitTimeout: DefaultAuthWaitTimeout,
 	}
 }
 
@@ -130,6 +136,7 @@ func NewGoogleOpWithOptions(opts *GoogleOptions) BrowserOpenIdProvider {
 			HttpClient:                opts.HttpClient,
 			IssuedAtOffset:            opts.IssuedAtOffset,
 			CallbackHTML:              callbackHTMLOrDefault(opts.CallbackHTML),
+			AuthWaitTimeout:           opts.AuthWaitTimeout,
 			issuer:                    opts.Issuer,
 			DeviceFlow:                opts.DeviceFlow,
 			requestTokensOverrideFunc: nil,

--- a/providers/hello.go
+++ b/providers/hello.go
@@ -76,6 +76,11 @@ type HelloOptions struct {
 	// CallbackHTML is the HTML content to display to the user after successful
 	// authentication. If empty, defaults to "You may now close this window".
 	CallbackHTML string
+	// AuthWaitTimeout bounds how long the authorization-code localhost callback
+	// wait blocks for the user to finish browser login. Zero means
+	// DefaultAuthWaitTimeout (10 minutes). A negative value disables the
+	// library timeout so only the parent context can cancel the wait.
+	AuthWaitTimeout time.Duration
 }
 
 func GetDefaultHelloOpOptions() *HelloOptions {
@@ -89,11 +94,12 @@ func GetDefaultHelloOpOptions() *HelloOptions {
 			"http://localhost:10001/login-callback",
 			"http://localhost:11110/login-callback",
 		},
-		GQSign:         false,
-		OpenBrowser:    true,
-		HttpClient:     nil,
-		IssuedAtOffset: 1 * time.Minute,
-		CallbackHTML:   defaultCallbackHTML,
+		GQSign:          false,
+		OpenBrowser:     true,
+		HttpClient:      nil,
+		IssuedAtOffset:  1 * time.Minute,
+		CallbackHTML:    defaultCallbackHTML,
+		AuthWaitTimeout: DefaultAuthWaitTimeout,
 	}
 }
 
@@ -134,6 +140,7 @@ func newHelloOpWithOptions(opts *HelloOptions) *HelloOp {
 		HttpClient:                opts.HttpClient,
 		IssuedAtOffset:            opts.IssuedAtOffset,
 		CallbackHTML:              callbackHTMLOrDefault(opts.CallbackHTML),
+		AuthWaitTimeout:           opts.AuthWaitTimeout,
 		issuer:                    opts.Issuer,
 		requestTokensOverrideFunc: nil,
 		publicKeyFinder: discover.PublicKeyFinder{

--- a/providers/standard_provider.go
+++ b/providers/standard_provider.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/openpubkey/openpubkey/discover"
+	"github.com/openpubkey/openpubkey/internal/httpserver"
 	simpleoidc "github.com/openpubkey/openpubkey/oidc"
 	"github.com/openpubkey/openpubkey/pktoken/clientinstance"
 	"github.com/openpubkey/openpubkey/providers/qrcode"
@@ -39,6 +41,8 @@ import (
 )
 
 const defaultCallbackHTML = "You may now close this window"
+
+const callbackServerShutdownTimeout = time.Second
 
 func callbackHTMLOrDefault(value string) string {
 	if value == "" {
@@ -103,6 +107,12 @@ type StandardOpOptions struct {
 	// CallbackHTML is the HTML content to display to the user after successful
 	// authentication. If empty, defaults to "You may now close this window".
 	CallbackHTML string
+	// AuthWaitTimeout bounds how long the authorization-code localhost callback
+	// wait blocks for the user to finish browser login. Zero means
+	// DefaultAuthWaitTimeout (10 minutes). A negative value disables the
+	// library timeout so only the parent context can cancel the wait. Device
+	// flow continues to follow the OP's expires_in and is unaffected.
+	AuthWaitTimeout time.Duration
 }
 
 func GetDefaultStandardOpOptions(issuer string, clientID string) *StandardOpOptions {
@@ -125,6 +135,7 @@ func GetDefaultStandardOpOptions(issuer string, clientID string) *StandardOpOpti
 		HttpClient:        nil,
 		IssuedAtOffset:    1 * time.Minute,
 		CallbackHTML:      defaultCallbackHTML,
+		AuthWaitTimeout:   DefaultAuthWaitTimeout,
 	}
 }
 
@@ -151,6 +162,7 @@ func newStandardOpWithOptions(opts *StandardOpOptions) *StandardOp {
 		HttpClient:                opts.HttpClient,
 		IssuedAtOffset:            opts.IssuedAtOffset,
 		CallbackHTML:              callbackHTMLOrDefault(opts.CallbackHTML),
+		AuthWaitTimeout:           opts.AuthWaitTimeout,
 		issuer:                    opts.Issuer,
 		requestTokensOverrideFunc: nil,
 		publicKeyFinder: discover.PublicKeyFinder{
@@ -176,6 +188,7 @@ type StandardOp struct {
 	HttpClient        *http.Client
 	IssuedAtOffset    time.Duration
 	CallbackHTML      string
+	AuthWaitTimeout   time.Duration
 	ExtraURLParamOpts map[string]string // Use this to set additional URL params on auth request to the OP (works with auth code and device flow)
 	issuer            string
 	server            *http.Server
@@ -232,11 +245,18 @@ func (s *StandardOp) defaultRequestTokens(ctx context.Context, cicHash string) (
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = ln.Close() }()
 	chTokens := make(chan *oidc.Tokens[*oidc.IDTokenClaims], 1)
 	chErr := make(chan error, 1)
+	httpSessionDone := make(chan struct{}, 1)
 
 	mux := http.NewServeMux()
-	s.server = &http.Server{Handler: mux}
+	s.server = &http.Server{
+		Handler: mux,
+		BaseContext: func(net.Listener) context.Context {
+			return ctx
+		},
+	}
 
 	cookieHandler, err := configCookieHandler()
 	if err != nil {
@@ -291,7 +311,7 @@ func (s *StandardOp) defaultRequestTokens(ctx context.Context, cicHash string) (
 	}
 
 	shutdownServer := func() {
-		if err := s.server.Shutdown(ctx); err != nil {
+		if err := httpserver.Shutdown(s.server, callbackServerShutdownTimeout); err != nil {
 			_, _ = fmt.Fprintf(s.ErrWriter(), "Failed to shutdown HTTP server: %v\n", err)
 		}
 	}
@@ -325,8 +345,8 @@ func (s *StandardOp) defaultRequestTokens(ctx context.Context, cicHash string) (
 		// Useful for redirecting the user's browser window that just finished OIDC Auth flow to the
 		// MFA Cosigner Auth URI.
 		if s.httpSessionHook != nil {
+			defer func() { httpSessionDone <- struct{}{} }()
 			s.httpSessionHook(w, r)
-			defer shutdownServer() // If no http session hook is set, we do server shutdown in RequestTokens
 		} else {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			_, _ = w.Write([]byte(s.CallbackHTML))
@@ -336,7 +356,9 @@ func (s *StandardOp) defaultRequestTokens(ctx context.Context, cicHash string) (
 	callbackPath := redirectURI.Path
 	mux.Handle(callbackPath, rp.CodeExchangeHandler(marshalToken, relyingParty))
 
+	serveDone := make(chan struct{})
 	go func() {
+		defer close(serveDone)
 		err := s.server.Serve(ln)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			select {
@@ -345,6 +367,23 @@ func (s *StandardOp) defaultRequestTokens(ctx context.Context, cicHash string) (
 			}
 		}
 	}()
+	handoffHTTPServer := false
+	defer func() {
+		if !handoffHTTPServer {
+			shutdownServer()
+		}
+	}()
+	if s.httpSessionHook != nil {
+		go func() {
+			select {
+			case <-httpSessionDone:
+				shutdownServer()
+			case <-serveDone:
+			case <-ctx.Done():
+				_ = s.server.Close()
+			}
+		}()
+	}
 
 	// Open /login on the redirect URI's actual host, not a hardcoded
 	// "localhost", so the initial navigation targets the same address family
@@ -353,31 +392,27 @@ func (s *StandardOp) defaultRequestTokens(ctx context.Context, cicHash string) (
 
 	if s.loginURIHook != nil {
 		if err := s.loginURIHook(loginURI); err != nil {
-			shutdownServer()
 			return nil, fmt.Errorf("login URI hook failed: %w", err)
 		}
 	}
 
 	s.presentLoginURI(loginURI)
 
-	// If httpSessionHook is not defined shutdown the server when done,
-	// otherwise keep it open for the httpSessionHook
-	// If httpSessionHook is set we handle both possible cases to ensure
-	// the server is shutdown:
-	// 1. We shut it down if an error occurs in the marshalToken handler
-	// 2. We shut it down if the marshalToken handler completes
-	if s.httpSessionHook == nil {
-		defer shutdownServer()
-	}
+	authCtx, cancelAuth := WithAuthWaitTimeout(ctx, s.AuthWaitTimeout)
+	defer cancelAuth()
+
 	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	case <-authCtx.Done():
+		// Authentication has been canceled, so do not wait for active callback
+		// handlers to drain. Closing also unblocks the deferred graceful shutdown.
+		_ = s.server.Close()
+		return nil, AuthWaitError(authCtx, s.AuthWaitTimeout)
 	case err := <-chErr:
-		if s.httpSessionHook != nil {
-			defer shutdownServer()
-		}
 		return nil, err
 	case retTokens := <-chTokens:
+		// A session hook still owns the active browser request. It will shut
+		// the server down after it has written the redirect or response.
+		handoffHTTPServer = s.httpSessionHook != nil
 		// retTokens is a zitadel/oidc struct. We turn it into our simpler token struct
 		return &simpleoidc.Tokens{
 			IDToken:      nilIfEmpty(retTokens.IDToken),

--- a/providers/standard_provider_test.go
+++ b/providers/standard_provider_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -378,6 +379,110 @@ func TestLoginURIHookRecoversFromBrowserOpenFailure(t *testing.T) {
 	require.Contains(t, errorOutput.String(), "Failed to open URL: browser unavailable")
 }
 
+func TestAuthorizationCodeAuthWaitTimeoutClosesCallbackServer(t *testing.T) {
+	op, _ := newAuthorizationURLTestOp(t, false)
+	op.AuthWaitTimeout = 50 * time.Millisecond
+	var loginURI string
+	op.SetLoginURIHook(func(uri string) error {
+		loginURI = uri
+		return nil
+	})
+
+	tokens, err := op.RequestTokens(context.Background(), GenCIC(t))
+	require.Nil(t, tokens)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "authentication timed out after waiting 50ms")
+	requireHTTPListenerClosed(t, loginURI)
+}
+
+func TestAuthorizationCodeParentDeadlineIsNotReportedAsAuthTimeout(t *testing.T) {
+	op, _ := newAuthorizationURLTestOp(t, false)
+	op.AuthWaitTimeout = time.Hour
+	op.SetLoginURIHook(func(string) error { return nil })
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	tokens, err := op.RequestTokens(ctx, GenCIC(t))
+	require.Nil(t, tokens)
+	require.Equal(t, context.DeadlineExceeded, err)
+	require.NotContains(t, err.Error(), "authentication timed out")
+}
+
+func TestHTTPSessionHookDoesNotBlockRequestTokens(t *testing.T) {
+	op, completeAuthentication := newAuthorizationURLTestOp(t, false)
+	hookStarted := make(chan struct{})
+	releaseHook := make(chan struct{})
+	hookDone := make(chan struct{})
+	op.HookHTTPSession(func(w http.ResponseWriter, _ *http.Request) {
+		close(hookStarted)
+		<-releaseHook
+		w.WriteHeader(http.StatusFound)
+		close(hookDone)
+	})
+
+	var loginURI string
+	authenticationDone := make(chan error, 1)
+	op.SetLoginURIHook(func(uri string) error {
+		loginURI = uri
+		go func() { authenticationDone <- completeAuthentication(uri) }()
+		return nil
+	})
+
+	cic := GenCIC(t)
+	requestDone := make(chan error, 1)
+	go func() {
+		_, err := op.RequestTokens(context.Background(), cic)
+		requestDone <- err
+	}()
+	select {
+	case <-hookStarted:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP session hook did not start")
+	}
+	select {
+	case err := <-requestDone:
+		require.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("RequestTokens waited for the HTTP session hook")
+	}
+
+	close(releaseHook)
+	select {
+	case <-hookDone:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP session hook did not finish")
+	}
+	select {
+	case err := <-authenticationDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("browser authentication request did not finish")
+	}
+	http.DefaultTransport.(*http.Transport).CloseIdleConnections()
+	require.Eventually(t, func() bool {
+		parsedURL, err := url.Parse(loginURI)
+		if err != nil {
+			return false
+		}
+		connection, err := net.DialTimeout("tcp", parsedURL.Host, 20*time.Millisecond)
+		if connection != nil {
+			_ = connection.Close()
+		}
+		return err != nil
+	}, time.Second, 10*time.Millisecond, "callback listener remained open after the hook finished")
+}
+
+func requireHTTPListenerClosed(t *testing.T, rawURL string) {
+	t.Helper()
+	parsedURL, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	connection, err := net.DialTimeout("tcp", parsedURL.Host, 100*time.Millisecond)
+	if connection != nil {
+		_ = connection.Close()
+	}
+	require.Error(t, err, "callback listener %s is still accepting connections", parsedURL.Host)
+}
+
 func TestReuseBrowserWindowHookDoesNotPrintLoginURI(t *testing.T) {
 	op, completeAuthentication := newAuthorizationURLTestOp(t, true)
 	var output bytes.Buffer
@@ -385,15 +490,20 @@ func TestReuseBrowserWindowHookDoesNotPrintLoginURI(t *testing.T) {
 
 	redirectCh := make(chan string, 1)
 	op.ReuseBrowserWindowHook(redirectCh)
+	loginURICh := make(chan string, 1)
+	authenticationDone := make(chan error, 1)
 	go func() {
 		uri := <-redirectCh
-		_ = completeAuthentication(uri)
+		loginURICh <- uri
+		authenticationDone <- completeAuthentication(uri)
 	}()
 
 	tokens, err := op.RequestTokens(context.Background(), GenCIC(t))
 	require.NoError(t, err)
 	require.NotNil(t, tokens)
 	require.NotContains(t, output.String(), "Open your browser to:")
+	require.NoError(t, <-authenticationDone)
+	requireHTTPListenerClosed(t, <-loginURICh)
 }
 
 func TestOpenBrowserSuccessDoesNotPrintLoginURI(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a configurable timeout to browser authentication flows, defaulting to 10 minutes.

This applies to the web chooser, OIDC callback, and cosigner callback servers. It also ensures library-owned servers close cleanly on success, failure, cancellation, or timeout while preserving caller context errors.

A negative timeout disables the library deadline. Device flow is unchanged.

## Compatibility

Clients using constructors or keyed struct literals are unaffected. `opkssh` compiles against these changes without modification.

## Testing

- Verified `opkssh` compile against the updated library