### PR TITLE
Add optional AudClaimPrefix for aud-commitment PK Tokens

### DIFF
--- a/docs/pktoken.md
+++ b/docs/pktoken.md
@@ -27,6 +27,7 @@ In this document we provide needed background on JSON Web Signatures (JWS), ID T
       - [GQ Signing](#gq-signing)
     - [GQ Signed Audience-bound PK Tokens - GitHub Example](#gq-signed-audience-bound-pk-tokens---github-example)
       - [Audience-Commitment](#audience-commitment)
+      - [Namespacing the Audience-Commitment](#namespacing-the-audience-commitment)
       - [GQ Signatures Are Required For Aud-Commitment PK Tokens](#gq-signatures-are-required-for-aud-commitment-pk-tokens)
     - [GQ-Commitment PK Tokens (Gitlab-CI Example)](#gq-commitment-pk-tokens-gitlab-ci-example)
       - [GQ-Commitment to the CIC](#gq-commitment-to-the-cic)
@@ -570,6 +571,14 @@ nonce = SHA3(
 ```
 
 User identity ID Token issuance flows set the `aud` to a unique identifier to scope the ID Token to a particular service or OIDC client. This is done, among other reasons to prevent a malicious service from replaying the ID Tokens it receives from users to impersonate those users to another service. Allowing the requesting party to specify the `aud` as is done in machine identity would be insecure for user identity. However it is both secure and the primary pattern in machine identity flows.
+
+#### Namespacing the Audience-Commitment
+
+By default the `aud` is exactly the cicHash. A relying party may instead require a namespace prefix, so that the `aud` is the prefix followed by the cicHash, by setting `AudClaimPrefix` in `ProviderVerifierOpts`. This is optional and off by default.
+
+Because the requesting party chooses the `aud` in machine identity flows, an unprefixed commitment is a bare opaque string that could coincide with an identifier some other service expects for itself. Using a distinct `aud` value for a distinct use of JWTs from the same issuer is the cross-JWT confusion mitigation recommended by [RFC 8725 Section 3.12](https://www.rfc-editor.org/rfc/rfc8725.html#section-3.12). Note that `aud` values are `StringOrURI`, so a prefix containing a `:` must form a valid URI ([RFC 7519 Section 2](https://www.rfc-editor.org/rfc/rfc7519.html#section-2)); `example-rp:` is a legal scheme, `example_rp:` is not.
+
+This differs from the `OPENPUBKEY-PKTOKEN:` prefix required for GQ-commitments. That prefix is mandatory and exists to stop an existing ID Token being repurposed as a PK Token, a risk that does not apply here because the `aud` *is* the commitment. This prefix is optional and exists only to namespace the audience.
 
 #### GQ Signatures Are Required For Aud-Commitment PK Tokens
 

--- a/providers/providerverifier.go
+++ b/providers/providerverifier.go
@@ -65,6 +65,9 @@ type ProviderVerifierOpts struct {
 	// If empty (not set), defaults to AudPrefixForGQCommitment ("OPENPUBKEY-PKTOKEN:").
 	// Set to a custom value to use a different prefix.
 	GQAudiencePrefix string
+	// AudClaimPrefix optionally requires the aud to be this prefix followed by
+	// the cicHash. Only valid with AUD_CLAIM. See RFC 8725 Section 3.12.
+	AudClaimPrefix string
 }
 
 // Creates a new ProviderVerifier with required fields
@@ -118,6 +121,10 @@ func (v *DefaultProviderVerifier) VerifyIDToken(ctx context.Context, idToken []b
 		if v.options.GQAudiencePrefix != "" && v.options.GQAudiencePrefix != AudPrefixForGQCommitment {
 			return fmt.Errorf("GQAudiencePrefix is set but CommitType does not use GQCommitment")
 		}
+	}
+
+	if v.options.AudClaimPrefix != "" && v.commitType != CommitTypesEnum.AUD_CLAIM {
+		return fmt.Errorf("AudClaimPrefix is set but CommitType is not AUD_CLAIM")
 	}
 
 	idt, err := oidc.NewJwt(idToken)
@@ -282,6 +289,19 @@ func (v *DefaultProviderVerifier) verifyCommitment(idt *oidc.Jwt, cic *clientins
 		commitment, commitmentFound = claims[v.commitType.Claim]
 		if !commitmentFound {
 			return fmt.Errorf("missing commitment claim %s", v.commitType.Claim)
+		}
+
+		if v.options.AudClaimPrefix != "" {
+			audStr, ok := commitment.(string)
+			if !ok {
+				return fmt.Errorf("audience claim must be a string when AudClaimPrefix is set, got %T", commitment)
+			}
+			rest, found := strings.CutPrefix(audStr, v.options.AudClaimPrefix)
+			if !found {
+				return fmt.Errorf("audience claim must be prefixed by (%s), got (%s) instead",
+					v.options.AudClaimPrefix, audStr)
+			}
+			commitment = rest
 		}
 	}
 

--- a/providers/providerverifier_test.go
+++ b/providers/providerverifier_test.go
@@ -476,3 +476,169 @@ func TestGQCommitmentArrayAudReturnsError(t *testing.T) {
 	err = pv.VerifyIDToken(context.Background(), tokens.IDToken, cic)
 	require.ErrorContains(t, err, "must be a string")
 }
+
+func TestAudClaimPrefix(t *testing.T) {
+	const customPrefix = "dd-attest:"
+	clientID := "test-client-id"
+	issuer := "mockIssuer"
+
+	testCases := []struct {
+		name           string
+		audClaimPrefix string
+		commitFunc     func(*mocks.IDTokenTemplate, string)
+		expError       string
+	}{
+		{
+			name:           "prefixed audience verifies",
+			audClaimPrefix: customPrefix,
+			commitFunc: func(idtTemp *mocks.IDTokenTemplate, cicHash string) {
+				idtTemp.Aud = customPrefix + cicHash
+			},
+		},
+		{
+			name:           "bare cicHash rejected when a prefix is required",
+			audClaimPrefix: customPrefix,
+			commitFunc:     mocks.AddAudCommit,
+			expError:       "audience claim must be prefixed by",
+		},
+		{
+			name:           "wrong prefix rejected",
+			audClaimPrefix: customPrefix,
+			commitFunc: func(idtTemp *mocks.IDTokenTemplate, cicHash string) {
+				idtTemp.Aud = "other-tool:" + cicHash
+			},
+			expError: "audience claim must be prefixed by",
+		},
+		{
+			name:           "correct prefix but wrong commitment still rejected",
+			audClaimPrefix: customPrefix,
+			commitFunc: func(idtTemp *mocks.IDTokenTemplate, _ string) {
+				idtTemp.Aud = customPrefix + "not-the-cic-hash"
+			},
+			expError: "commitment claim doesn't match",
+		},
+		{
+			name:           "unset prefix keeps the bare cicHash behaviour",
+			audClaimPrefix: "",
+			commitFunc:     mocks.AddAudCommit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			idtTemplate := mocks.IDTokenTemplate{
+				Issuer:      issuer,
+				Nonce:       "empty",
+				NoNonce:     true,
+				Alg:         "RS256",
+				ExtraClaims: map[string]any{},
+				CommitFunc:  tc.commitFunc,
+			}
+
+			cic := GenCICExtra(t, map[string]any{})
+
+			op, backendMock, _, err := NewMockProvider(MockProviderOpts{
+				Issuer:     issuer,
+				Alg:        "RS256",
+				ClientID:   clientID,
+				GQSign:     false,
+				NumKeys:    2,
+				CommitType: CommitTypesEnum.AUD_CLAIM,
+				VerifierOpts: ProviderVerifierOpts{
+					CommitType:        CommitTypesEnum.AUD_CLAIM,
+					ClientID:          clientID,
+					SkipClientIDCheck: true,
+					AudClaimPrefix:    tc.audClaimPrefix,
+				},
+			})
+			require.NoError(t, err)
+
+			opSignKey, keyID, _ := backendMock.RandomSigningKey()
+			idtTemplate.KeyID = keyID
+			idtTemplate.SigningKey = opSignKey
+			backendMock.SetIDTokenTemplate(&idtTemplate)
+
+			tokens, err := op.RequestTokens(context.Background(), cic)
+			require.NoError(t, err)
+
+			pv := NewProviderVerifier(issuer, ProviderVerifierOpts{
+				CommitType:        CommitTypesEnum.AUD_CLAIM,
+				DiscoverPublicKey: &backendMock.PublicKeyFinder,
+				SkipClientIDCheck: true,
+				AudClaimPrefix:    tc.audClaimPrefix,
+			})
+
+			err = pv.VerifyIDToken(context.Background(), tokens.IDToken, cic)
+			if tc.expError != "" {
+				require.ErrorContains(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAudClaimPrefixRejectedForOtherCommitTypes(t *testing.T) {
+	for _, commitType := range []CommitType{CommitTypesEnum.NONCE_CLAIM, CommitTypesEnum.GQ_BOUND} {
+		pv := NewProviderVerifier("mockIssuer", ProviderVerifierOpts{
+			CommitType:        commitType,
+			SkipClientIDCheck: true,
+			GQOnly:            commitType.GQCommitment,
+			AudClaimPrefix:    "dd-attest:",
+		})
+
+		// The guard runs before the token is parsed.
+		err := pv.VerifyIDToken(context.Background(), []byte("not.a.token"), GenCICExtra(t, map[string]any{}))
+		require.ErrorContains(t, err, "AudClaimPrefix is set but CommitType is not AUD_CLAIM")
+	}
+}
+
+func TestAudClaimPrefixArrayAudReturnsError(t *testing.T) {
+	const customPrefix = "dd-attest:"
+	issuer := "mockIssuer"
+	clientID := "test-client-id"
+
+	idtTemplate := mocks.IDTokenTemplate{
+		Issuer:      issuer,
+		Nonce:       "empty",
+		NoNonce:     true,
+		Alg:         "RS256",
+		ExtraClaims: map[string]any{"aud": []any{customPrefix + "abc", "other"}},
+		CommitFunc:  mocks.AddAudCommit,
+	}
+	cic := GenCICExtra(t, map[string]any{})
+
+	op, backendMock, _, err := NewMockProvider(MockProviderOpts{
+		Issuer:     issuer,
+		Alg:        "RS256",
+		ClientID:   clientID,
+		GQSign:     false,
+		NumKeys:    2,
+		CommitType: CommitTypesEnum.AUD_CLAIM,
+		VerifierOpts: ProviderVerifierOpts{
+			CommitType:        CommitTypesEnum.AUD_CLAIM,
+			ClientID:          clientID,
+			SkipClientIDCheck: true,
+		},
+	})
+	require.NoError(t, err)
+
+	opSignKey, keyID, _ := backendMock.RandomSigningKey()
+	idtTemplate.KeyID = keyID
+	idtTemplate.SigningKey = opSignKey
+	backendMock.SetIDTokenTemplate(&idtTemplate)
+
+	tokens, err := op.RequestTokens(context.Background(), cic)
+	require.NoError(t, err)
+
+	pv := NewProviderVerifier(issuer, ProviderVerifierOpts{
+		CommitType:        CommitTypesEnum.AUD_CLAIM,
+		DiscoverPublicKey: &backendMock.PublicKeyFinder,
+		SkipClientIDCheck: true,
+		AudClaimPrefix:    customPrefix,
+	})
+
+	// An array aud is valid per RFC 7519; verification must return an error, not panic.
+	err = pv.VerifyIDToken(context.Background(), tokens.IDToken, cic)
+	require.ErrorContains(t, err, "must be a string")
+}


### PR DESCRIPTION
## Why

In machine identity flows the requesting party chooses the `aud`, and in AUD_CLAIM mode we ask it to choose the cicHash. That leaves the commitment as a bare opaque string, so its safety rests on the OP refusing to sign audiences it doesn't own. If an OP will mint an arbitrary audience, a caller can request `aud` equal to an identifier some other service expects for itself and get an issuer-signed token that service will accept as addressed to it.

Using a distinct `aud` value for a distinct use of JWTs from the same issuer is the cross-JWT confusion mitigation recommended by [RFC 8725 Section 3.12](https://www.rfc-editor.org/rfc/rfc8725.html#section-3.12) (see also [Section 2.8](https://www.rfc-editor.org/rfc/rfc8725.html#section-2.8), and [RFC 9068 Section 5](https://www.rfc-editor.org/rfc/rfc9068.html#section-5), which makes it a MUST for access tokens). A namespace prefix makes the collision structurally impossible.

## What

`AudClaimPrefix` in `ProviderVerifierOpts`. When set, the `aud` must be the prefix followed by the cicHash; the prefix is stripped before the commitment comparison.

- Off by default — existing bare-cicHash verification is byte-for-byte unchanged.
- Only valid with `AUD_CLAIM`, mirroring how `GQAudiencePrefix` is rejected outside GQ commitments.
- Verification-side only, exactly like `GQAudiencePrefix`: the caller sets the audience when requesting the token, openpubkey never sets it.
- A non-string `aud` (e.g. an array, which is legal per RFC 7519) now returns a typed error rather than falling through to a confusing "commitment claim doesn't match".

## Relationship to the GQ prefix

This is deliberately *not* the same thing as `OPENPUBKEY-PKTOKEN:`. That prefix is mandatory and prevents an existing ID Token being repurposed as a PK Token, because in GQ_BOUND the commitment lives in an attacker-choosable protected header. That risk doesn't apply here — in AUD_CLAIM the `aud` *is* the commitment, so a pre-existing token can't be repurposed unless its `aud` already equals the hash of a CIC the attacker holds the key for. `docs/pktoken.md` already says the GQ rule "does not apply to other types of PK Tokens", and this PR doesn't change that. The justification here is namespacing, not binding.

## Note on prefix syntax

`aud` values are `StringOrURI`, so a prefix containing a `:` must form a valid URI ([RFC 7519 Section 2](https://www.rfc-editor.org/rfc/rfc7519.html#section-2)). `example-rp:` is a legal scheme; `example_rp:` is not. Documented rather than enforced, since the prefix is caller-supplied and non-colon prefixes are also valid.

## Open question for reviewers

Should `GithubOp` gain a matching issuance-side option? It currently hardcodes the bare cicHash as the audience, and `NewGithubOp` has no options struct, so adding one is a wider API change. Left out to keep this reviewable — happy to follow up.